### PR TITLE
Use AWS retryer to handle retryable and failed http requests

### DIFF
--- a/pkg/sessions.go
+++ b/pkg/sessions.go
@@ -2,11 +2,11 @@ package exporter
 
 import (
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/client"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/apigateway"


### PR DESCRIPTION
It is possible that Cloudwatch APIs get rate limited. Using AWS retryer would handle retries for throttling errors efficiently