### PR TITLE
Add a ResourceFilter to ElasticBeanstalk

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -136,6 +136,9 @@ var SupportedServices = serviceConfigs{
 	{
 		Namespace: "AWS/ElasticBeanstalk",
 		Alias:     "beanstalk",
+		ResourceFilters: []*string{
+			aws.String("elasticbeanstalk:environment"),
+		},
 	},
 	{
 		Namespace: "AWS/Billing",


### PR DESCRIPTION
in `v0.49.2` no ElasticBeanstalk data was returned when using auto-discovery.

In the `master` branch, the data was returned, but the `aws_info` metrics were missing.