### PR TITLE
Include RDS Proxy metrics within the RDS namespace.

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -725,10 +725,12 @@ var SupportedServices = serviceConfigs{
 		ResourceFilters: []*string{
 			aws.String("rds:db"),
 			aws.String("rds:cluster"),
+			aws.String("rds:db-proxy"),
 		},
 		DimensionRegexps: []*regexp.Regexp{
 			regexp.MustCompile(":cluster:(?P<DBClusterIdentifier>[^/]+)"),
 			regexp.MustCompile(":db:(?P<DBInstanceIdentifier>[^/]+)"),
+			regexp.MustCompile(":db-proxy:(?P<ProxyIdentifier>[^/]+)"),
 		},
 	},
 	{


### PR DESCRIPTION
Example output:

```
aws_rds_database_connections_sum{account_alias="example-account",account_id="redacted-id-here",dimension_DBInstanceIdentifier="",dimension_DatabaseClass="",dimension_EngineName="",dimension_ProxyName="mysql-example-proxy",dimension_Target="",dimension_TargetGroup="",dimension_TargetRole="",name="global",region="us-west-2"} 5595
aws_rds_database_connections_sum{account_alias="example-account",account_id="redacted-id-here",dimension_DBInstanceIdentifier="",dimension_DatabaseClass="",dimension_EngineName="",dimension_ProxyName="mysql-example-proxy",dimension_Target="",dimension_TargetGroup="default",dimension_TargetRole="READWRITE",name="global",region="us-west-2"} 5595
aws_rds_database_connections_sum{account_alias="example-account",account_id="redacted-id-here",dimension_DBInstanceIdentifier="",dimension_DatabaseClass="",dimension_EngineName="",dimension_ProxyName="mysql-example-proxy",dimension_Target="",dimension_TargetGroup="default",dimension_TargetRole="READ_ONLY",name="global",region="us-west-2"} 0
aws_rds_database_connections_sum{account_alias="example-account",account_id="redacted-id-here",dimension_DBInstanceIdentifier="",dimension_DatabaseClass="",dimension_EngineName="",dimension_ProxyName="mysql-example-proxy",dimension_Target="db:mysql-example-proxy",dimension_TargetGroup="default",dimension_TargetRole="",name="global",region="us-west-2"} 5595
aws_rds_database_connections_sum{account_alias="example-account",account_id="redacted-id-here",dimension_DBInstanceIdentifier="mysql-example-proxy",dimension_DatabaseClass="",dimension_EngineName="",dimension_ProxyName="",dimension_Target="",dimension_TargetGroup="",dimension_TargetRole="",name="arn:aws:rds:us-west-2:redacted-id-here:db:mysql-example-proxy",region="us-west-2"} 6251
```


Fixes #1460