### PR TITLE
Add parentheses to sanitize list to prevent invalid metric name generation

### DIFF
--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -88,6 +88,8 @@ var replacer = strings.NewReplacer(
 	"@", "_",
 	"<", "_",
 	">", "_",
+	"(", "_",
+	")", "_",
 	"%", "_percent",
 )
 
@@ -190,7 +192,7 @@ func sanitize(text string) string {
 	b := []byte(text)
 	for i := 0; i < len(b); i++ {
 		switch b[i] {
-		case ' ', ',', '\t', '/', '\\', '.', '-', ':', '=', '@', '<', '>':
+		case ' ', ',', '\t', '/', '\\', '.', '-', ':', '=', '@', '<', '>', '(', ')':
 			b[i] = '_'
 		}
 	}


### PR DESCRIPTION
Using `PR(:1)` type of statistics and others, that have brackets, leads to an error. [Clodwatch types reference](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html)

Config example:
```yaml
discovery:
  jobs:
    - type: AWS/ELB
      regions:
        - eu-central-1
      period: 60
      length: 60
      dimensionNameRequirements:
        - AvailabilityZone
        - LoadBalancerName
      metrics:
        - name: Latency
          statistics: ["PR(:10)"]
```

Error:
```
 error(s) occurred:
* "aws_elb_latency_pr(_10)" is not a valid metric name
```
After fix it works like this:
```
aws_elb_latency_pr__10_{account_id="***...
```

Looks ugly from my POV but works and requires minimal changes 😃 