### PR TITLE
Remove 'needs' from workflows with only one job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,11 +1,10 @@
 on: push
 
-name: Build and test
+name: Build Docker image
 jobs:
   buildDockerImage:
     name: Publish master branch artifacts
     runs-on: ubuntu-latest
-    needs: [build, verify]
     if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,10 @@ on:
       - 'v*'
 
 jobs:
-  buildDockerImage:
-    name: Publish release artefacts
+  publishDockerImage:
+    name: Publish release artifacts
     runs-on: ubuntu-latest
-    needs: [build, verify]
-    if: |
-      (github.repository == 'prometheus-community/yet-another-cloudwatch-exporter')
-      &&
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v.'))
+    if: github.repository == 'prometheus-community/yet-another-cloudwatch-exporter' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v.')
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5


### PR DESCRIPTION
When there's only one job, it must have no dependencies.