### PR TITLE
CI workflow: save_artifacts after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
       - uses: ./.github/promci/actions/setup_environment
       - run: make
+      - run: mkdir .build
       - uses: ./.github/promci/actions/save_artifacts
         with:
           directory: .build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: prometheus/promci@52c7012f5f0070d7281b8db4a119e21341d43c91 # v0.4.5
       - uses: ./.github/promci/actions/setup_environment
       - run: make
+      - uses: ./.github/promci/actions/save_artifacts
+        with:
+          directory: .build
       - run: git diff --exit-code
 
   verify-example-configs:


### PR DESCRIPTION
Seems that publish_main expects to find build artifacts.