### PR TITLE
Update container repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # YACE - yet another cloudwatch exporter
 
+[![Container on Quay](https://quay.io/repository/prometheuscommunity/yet-another-cloudwatch-exporter/status)][quay]
+[![Container on Docker Hub](https://img.shields.io/docker/pulls/prometheuscommunity/yet-another-cloudwatch-exporter.svg?maxAge=604800)][docker]
+
 YACE, or `yet another cloudwatch exporter`, is a [Prometheus exporter](https://prometheus.io/docs/instrumenting/exporters/#exporters-and-integrations) for [AWS CloudWatch](http://aws.amazon.com/cloudwatch/) metrics. It is written in Go and uses the official AWS SDK.
 
 ## News
@@ -293,7 +296,7 @@ predict_linear(aws_es_free_storage_space_minimum[2d], 86400 * 7) + on (name) gro
 to support local testing all AWS urls can be overridden with by setting an environment variable `AWS_ENDPOINT_URL`
 ```shell
 docker run -d --rm -v $PWD/credentials:/exporter/.aws/credentials -v $PWD/config.yml:/tmp/config.yml \
--e AWS_ENDPOINT_URL=http://localhost:4766 -p 5000:5000 --name yace ghcr.io/nerdswords/yet-another-cloudwatch-exporter:vx.xx.x # release version as tag - Do not forget the version 'v'
+-e AWS_ENDPOINT_URL=http://localhost:4766 -p 5000:5000 --name yace quay.io/prometheuscommunity/yet-another-cloudwatch-exporter:latest
 ```
 
 ## Options
@@ -365,3 +368,6 @@ go without losing data. ELB metrics on AWS are written every 5 minutes (300) in 
 
 * [Justin Santa Barbara](https://github.com/justinsb) - For telling me about AWS tags api which simplified a lot - Thanks!
 * [Brian Brazil](https://github.com/brian-brazil) - Who gave a lot of feedback regarding UX and prometheus lib - Thanks!
+
+[quay]: https://quay.io/repository/prometheuscommunity/yet-another-cloudwatch-exporter
+[docker]: https://hub.docker.com/r/prometheuscommunity/yet-another-cloudwatch-exporter

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ See the [Releases](https://github.com/prometheus-community/yet-another-cloudwatc
 
 Docker images are available on GitHub Container Registry [here](https://github.com/prometheus-community/yet-another-cloudwatch-exporter/pkgs/container/yet-another-cloudwatch-exporter).
 
-The image name is `ghcr.io/nerdswords/yet-another-cloudwatch-exporter` and we only support tags of the form `vX.Y.Z`.
+The image name is `quay.io/prometheuscommunity/yet-another-cloudwatch-exporter` and we support tags of the form `vX.Y.Z`.
 
 To pull and run the image locally use:
 
@@ -19,7 +19,7 @@ docker run -d --rm \
   -v $PWD/credentials:/exporter/.aws/credentials \
   -v $PWD/config.yml:/tmp/config.yml \
   -p 5000:5000 \
-  --name yace ghcr.io/nerdswords/yet-another-cloudwatch-exporter:vX.Y.Z
+  --name yace quay.io/prometheuscommunity/yet-another-cloudwatch-exporter:latest
 ```
 
 Do not forget the `v` prefix in the image version tag.
@@ -65,7 +65,7 @@ spec:
     spec:
       containers:
       - name: yace
-        image: ghcr.io/nerdswords/yet-another-cloudwatch-exporter:vX.Y.Z # release version as tag - Do not forget the version 'v'
+        image: quay.io/prometheuscommunity/yet-another-cloudwatch-exporter:vX.Y.Z # release version as tag - Do not forget the version 'v'
         imagePullPolicy: IfNotPresent
         args:
           - "--config.file=/tmp/config.yml"


### PR DESCRIPTION
Update docs references to the container repos for the new prometheus community container mirrors.

Fixes: https://github.com/prometheus-community/yet-another-cloudwatch-exporter/issues/1603