### PR TITLE
Add example of Lambda Edge

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,4 +36,4 @@ jobs:
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:
           args: --verbose
-          version: v1.62.0
+          version: v1.63.4

--- a/Makefile.common
+++ b/Makefile.common
@@ -61,7 +61,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 SKIP_GOLANGCI_LINT :=
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.62.0
+GOLANGCI_LINT_VERSION ?= v1.63.4
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64/arm64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))

--- a/examples/lambda_edge.yml
+++ b/examples/lambda_edge.yml
@@ -1,5 +1,5 @@
   # We can't configure discovery job for edge lambda function but static works.,he region is always us-east-1. 
-  # Other regions can be added in use as edge locations. 
+  # Other regions can be added in use as edge locations 
   apiVersion: v1alpha1
   static:
     - name: us-east-1.<edge_lambda_function_name>

--- a/examples/lambda_edge.yml
+++ b/examples/lambda_edge.yml
@@ -1,0 +1,22 @@
+  # We can't configure discovery job for edge lambda function but static works.,he region is always us-east-1. 
+  # Other regions can be added in use as edge locations. 
+  apiVersion: v1alpha1
+  static:
+    - name: us-east-1.<edge_lambda_function_name>
+      namespace: AWS/Lambda
+      regions:
+        - eu-central-1
+        - us-east-1
+        - us-west-2
+        - ap-southeast-1
+      period: 600
+      length: 600
+      metrics:
+        - name: Invocations
+          statistics: [Sum]
+        - name: Errors
+          statistics: [Sum]
+        - name: Throttles
+          statistics: [Sum]
+        - name: Duration
+          statistics: [Average, Maximum, Minimum, p90]

--- a/pkg/job/maxdimassociator/associator_logging_test.go
+++ b/pkg/job/maxdimassociator/associator_logging_test.go
@@ -1,0 +1,45 @@
+package maxdimassociator
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+func TestAssociatorLogging(t *testing.T) {
+	type testcase struct {
+		level slog.Level
+	}
+	for name, tc := range map[string]testcase{
+		"debug enabled":  {level: slog.LevelDebug},
+		"debug disabled": {level: slog.LevelInfo},
+	} {
+		t.Run(name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
+				Level: tc.level,
+			}))
+			associator := NewAssociator(logger, config.SupportedServices.GetService("AWS/Logs").ToModelDimensionsRegexp(), logGroupResources)
+			res, skip := associator.AssociateMetricToResource(&model.Metric{
+				MetricName: "DeliveryThrottling",
+				Namespace:  "AWS/Logs",
+				Dimensions: []model.Dimension{
+					{Name: "LogGroupName", Value: "/aws/lambda/log-group-1"},
+				},
+			})
+			require.NotNil(t, res)
+			require.False(t, skip)
+
+			assertion := require.NotContains
+			if tc.level == slog.LevelDebug {
+				assertion = require.Contains
+			}
+			assertion(t, buf.String(), "found mapping")
+		})
+	}
+}


### PR DESCRIPTION
Since we can't use Lambda@Edge as a discovery job, we can add it as static job. 
Not everyone may know about using as static job and it can be confusing when example configuration for Lambda don't work. 

This can help them. 