### PR TITLE
Make aws sdk v2 the default choice

### DIFF
--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -4,11 +4,11 @@ List of features or changes that are disabled by default since they are breaking
 
 You can enable them using the `-enable-feature` flag with a comma separated list of features. They may be enabled by default in future versions.
 
-## AWS SDK v2
+## AWS SDK v1
 
-`-enable-feature=aws-sdk-v2`
+`-enable-feature=aws-sdk-v1`
 
-Uses the v2 version of the aws sdk for go. The sdk v2 version was released in Jan 2021 and is marketed to come with large performance gains. This version offers a drastically different interface and should be compatible with sdk v2.
+Uses the v1 version of the aws sdk for go for backward compatibility. By default, YACE now uses AWS SDK v2 which was released in Jan 2021 and comes with large performance gains.
 
 ## Always return info metrics
 

--- a/pkg/config/feature_flags.go
+++ b/pkg/config/feature_flags.go
@@ -16,8 +16,8 @@ import "context"
 
 type flagsCtxKey struct{}
 
-// AwsSdkV2 is a feature flag used to enable the use of aws sdk v2 which is expected to come with performance benefits
-const AwsSdkV2 = "aws-sdk-v2"
+// AwsSdkV1 is a feature flag used to enable the use of aws sdk v1 (v2 is the default)
+const AwsSdkV1 = "aws-sdk-v1"
 
 // AlwaysReturnInfoMetrics is a feature flag used to enable the return of info metrics even when there are no corresponding CloudWatch metrics
 const AlwaysReturnInfoMetrics = "always-return-info-metrics"


### PR DESCRIPTION
Remove the `aws-sdk-v2` feature flag and replace it with `aws-sdk-v1`. This makes SDK v2 the default, unless v1 is explicitly enabled.