### PR TITLE
update resource association logic to try both with and without dimension fixes

### DIFF
--- a/pkg/job/maxdimassociator/associator.go
+++ b/pkg/job/maxdimassociator/associator.go
@@ -176,19 +176,31 @@ func (assoc Associator) AssociateMetricToResource(cwMetric *model.Metric) (*mode
 			// the dimensions computed for the mapping. Now compute a signature
 			// of the labels (names and values) of the dimensions of this mapping.
 			mappingFound = true
-			labels := buildLabelsMap(cwMetric, regexpMapping)
-			signature := prom_model.LabelsToSignature(labels)
+			dimFixApplied := false
+			for _, fun := range []func(string, model.Dimension) (model.Dimension, bool){fixDimension, nil} {
+				if !dimFixApplied && fun == nil {
+					// If no dimension fixes were applied, no need to try running again without the fixer
+					break
+				}
 
-			// Check if there's an entry for the labels (names and values) of the metric,
-			// and return the resource in case.
-			if resource, ok := regexpMapping.dimensionsMapping[signature]; ok {
-				logger.Debug("resource matched", "signature", signature)
-				return resource, false
+				var labels map[string]string
+				labels, dimFixApplied = buildLabelsMap(cwMetric, regexpMapping, fun)
+				signature := prom_model.LabelsToSignature(labels)
+
+				// Check if there's an entry for the labels (names and values) of the metric,
+				// and return the resource in case.
+				if resource, ok := regexpMapping.dimensionsMapping[signature]; ok {
+					logger.Debug("resource matched", "signature", signature)
+					return resource, false
+				}
+
+				// No resource was matched for the current signature.
+				logger.Debug("resource signature attempt not matched", "signature", signature)
 			}
 
-			// Otherwise, continue iterating across the rest of regex mappings
-			// to attempt to find another one with fewer dimensions.
-			logger.Debug("resource not matched", "signature", signature)
+			// No resource was matched for any signature, continue iterating across the
+			// rest of regex mappings to attempt to find another one with fewer dimensions.
+			logger.Debug("resource not matched")
 		}
 	}
 
@@ -204,38 +216,46 @@ func (assoc Associator) AssociateMetricToResource(cwMetric *model.Metric) (*mode
 	return nil, mappingFound
 }
 
-// buildLabelsMap returns a map of labels names and values.
+// buildLabelsMap returns a map of labels names and values, as well as whether the dimension fixer was applied.
 // For some namespaces, values might need to be modified in order
 // to match the dimension value extracted from ARN.
-func buildLabelsMap(cwMetric *model.Metric, regexpMapping *dimensionsRegexpMapping) map[string]string {
+func buildLabelsMap(cwMetric *model.Metric, regexpMapping *dimensionsRegexpMapping, dimFixer func(string, model.Dimension) (model.Dimension, bool)) (map[string]string, bool) {
 	labels := make(map[string]string, len(cwMetric.Dimensions))
+	dimFixApplied := false
 	for _, rDimension := range regexpMapping.dimensions {
 		for _, mDimension := range cwMetric.Dimensions {
-			name := mDimension.Name
-			value := mDimension.Value
-
-			// AmazonMQ is special - for active/standby ActiveMQ brokers,
-			// the value of the "Broker" dimension contains a number suffix
-			// that is not part of the resource ARN
-			if cwMetric.Namespace == "AWS/AmazonMQ" && name == "Broker" {
-				if amazonMQBrokerSuffix.MatchString(value) {
-					value = amazonMQBrokerSuffix.ReplaceAllString(value, "")
-				}
-			}
-
-			// AWS Sagemaker endpoint name may have upper case characters
-			// Resource ARN is only in lower case, hence transforming
-			// endpoint name value to be able to match the resource ARN
-			if cwMetric.Namespace == "AWS/SageMaker" && name == "EndpointName" {
-				value = strings.ToLower(value)
+			if dimFixer != nil {
+				mDimension, dimFixApplied = dimFixer(cwMetric.Namespace, mDimension)
 			}
 
 			if rDimension == mDimension.Name {
-				labels[name] = value
+				labels[mDimension.Name] = mDimension.Value
 			}
 		}
 	}
-	return labels
+	return labels, dimFixApplied
+}
+
+func fixDimension(namespace string, dim model.Dimension) (model.Dimension, bool) {
+	// AmazonMQ is special - for active/standby ActiveMQ brokers,
+	// the value of the "Broker" dimension contains a number suffix
+	// that is not part of the resource ARN
+	if namespace == "AWS/AmazonMQ" && dim.Name == "Broker" {
+		if amazonMQBrokerSuffix.MatchString(dim.Value) {
+			dim.Value = amazonMQBrokerSuffix.ReplaceAllString(dim.Value, "")
+			return dim, true
+		}
+	}
+
+	// AWS Sagemaker endpoint name may have upper case characters
+	// Resource ARN is only in lower case, hence transforming
+	// endpoint name value to be able to match the resource ARN
+	if namespace == "AWS/SageMaker" && dim.Name == "EndpointName" {
+		dim.Value = strings.ToLower(dim.Value)
+		return dim, true
+	}
+
+	return dim, false
 }
 
 // containsAll returns true if a contains all elements of b

--- a/pkg/job/maxdimassociator/associator_mq_test.go
+++ b/pkg/job/maxdimassociator/associator_mq_test.go
@@ -27,6 +27,11 @@ var rabbitMQBroker = &model.TaggedResource{
 	Namespace: "AWS/AmazonMQ",
 }
 
+var rabbitMQBrokerWithActiveStyleName = &model.TaggedResource{
+	ARN:       "arn:aws:mq:us-east-2:123456789012:broker:rabbitmq-broker-0:b-000-111-222-333",
+	Namespace: "AWS/AmazonMQ",
+}
+
 var activeMQBroker = &model.TaggedResource{
 	ARN:       "arn:aws:mq:us-east-2:123456789012:broker:activemq-broker:b-000-111-222-333",
 	Namespace: "AWS/AmazonMQ",
@@ -64,10 +69,26 @@ func TestAssociatorMQ(t *testing.T) {
 			expectedResource: rabbitMQBroker,
 		},
 		{
+			name: "should match with Broker dimension when broker name has a number suffix and does match ARN",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/AmazonMQ").ToModelDimensionsRegexp(),
+				resources:        []*model.TaggedResource{rabbitMQBrokerWithActiveStyleName},
+				metric: &model.Metric{
+					MetricName: "ProducerCount",
+					Namespace:  "AWS/AmazonMQ",
+					Dimensions: []model.Dimension{
+						{Name: "Broker", Value: "rabbitmq-broker-0"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: rabbitMQBrokerWithActiveStyleName,
+		},
+		{
 			// ActiveMQ allows active/standby modes where the `Broker` dimension has values
 			// like `brokername-1` and `brokername-2` which don't match the ARN (the dimension
 			// regex will extract `Broker` as `brokername` from ARN)
-			name: "should match with Broker dimension when broker name has a number suffix",
+			name: "should match with Broker dimension when broker name has a number suffix and doesn't match ARN",
 			args: args{
 				dimensionRegexps: config.SupportedServices.GetService("AWS/AmazonMQ").ToModelDimensionsRegexp(),
 				resources:        []*model.TaggedResource{activeMQBroker},


### PR DESCRIPTION
AmazonMQ has special associator logic to [match and remove a suffix `-[0-9]+$"` from the Broker dimension label](https://github.com/tristanburgess/yet-another-cloudwatch-exporter/blob/cb42c424cab98586e575b2a9be8a573ada0770e6/pkg/job/maxdimassociator/associator.go#L243). This problem solves the case where the resource name in the ARN indeed doesn't have that suffix, because of ActiveMQ adding the suffix to the `Broker` dimension, but causes an issue if the ARN actually does have that kind of suffix, because the customer named the resource that way.

This PR updates the label building logic to first try to apply any of the custom fixes. If any of them were applied, and there's no resource ARN match from the resulting label set signature, then we try to build a new label set signature with no fixes applied.