### PR TITLE
Speed up build metric name.

### DIFF
--- a/pkg/promutil/prometheus_test.go
+++ b/pkg/promutil/prometheus_test.go
@@ -23,30 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSplitString(t *testing.T) {
-	testCases := []struct {
-		input  string
-		output string
-	}{
-		{
-			input:  "GlobalTopicCount",
-			output: "Global.Topic.Count",
-		},
-		{
-			input:  "CPUUtilization",
-			output: "CPUUtilization",
-		},
-		{
-			input:  "StatusCheckFailed_Instance",
-			output: "Status.Check.Failed_Instance",
-		},
-	}
-
-	for _, tc := range testCases {
-		assert.Equal(t, tc.output, splitString(tc.input))
-	}
-}
-
 func TestSanitize(t *testing.T) {
 	testCases := []struct {
 		input  string


### PR DESCRIPTION
```
› benchstat before.log after.log 
goos: linux
goarch: amd64
pkg: github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/promutil
cpu: AMD Ryzen 7 3700X 8-Core Processor             
                                                                      │  before.log  │              after.log              │
                                                                      │    sec/op    │   sec/op     vs base                │
_BuildMetricName/aws_elasticache_cpuutilization_average-16              1026.0n ± 1%   653.2n ± 1%  -36.34% (p=0.000 n=10)
_BuildMetricName/aws_sagemaker_trainingjobs_cpuutilization_average-16   1157.5n ± 2%   737.8n ± 2%  -36.26% (p=0.000 n=10)
_BuildMetricName/aws_glue_driver_aggregate_bytes_read_average-16        1040.5n ± 1%   624.2n ± 1%  -40.01% (p=0.000 n=10)
_BuildMetricName/aws_glue_aggregate_glue_jobs_bytes_read_average-16     1013.5n ± 1%   600.4n ± 2%  -40.76% (p=0.000 n=10)
geomean                                                                  1.058µ        651.9n       -38.38%
```