### PR TITLE
Run tests in CI and fix failing tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,17 @@ on:
   workflow_call:
 
 jobs:
+  test_go:
+    name: Go tests
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/prometheus/golang-builder:1.23-base
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: prometheus/promci@c3c93a50d581b928af720f0134b2b2dad32a6c41 # v0.4.6
+      - uses: ./.github/promci/actions/setup_environment
+      - run: make test
+
   build:
     name: Build for common architectures
     runs-on: ubuntu-latest
@@ -61,7 +72,7 @@ jobs:
   publish_master:
     name: Publish master branch artifacts
     runs-on: ubuntu-latest
-    needs: [build_all, verify-example-configs]
+    needs: [test_go, build_all, verify-example-configs]
     if: |
       (github.repository == 'prometheus-community/yet-another-cloudwatch-exporter')
       &&
@@ -81,7 +92,7 @@ jobs:
   publish_release:
     name: Publish release artifacts
     runs-on: ubuntu-latest
-    needs: [build_all, verify-example-configs]
+    needs: [test_go, build_all, verify-example-configs]
     if: |
       (github.repository == 'prometheus-community/yet-another-cloudwatch-exporter')
       &&

--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -27,7 +27,7 @@ import (
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/model"
 )
 
-type scraper struct {
+type Scraper struct {
 	registry     atomic.Pointer[prometheus.Registry]
 	featureFlags []string
 }
@@ -38,8 +38,8 @@ type cachingFactory interface {
 	Clear()
 }
 
-func NewScraper(featureFlags []string) *scraper { //nolint:revive
-	s := &scraper{
+func NewScraper(featureFlags []string) *Scraper {
+	s := &Scraper{
 		registry:     atomic.Pointer[prometheus.Registry]{},
 		featureFlags: featureFlags,
 	}
@@ -47,7 +47,7 @@ func NewScraper(featureFlags []string) *scraper { //nolint:revive
 	return s
 }
 
-func (s *scraper) makeHandler() func(http.ResponseWriter, *http.Request) {
+func (s *Scraper) makeHandler() func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		handler := promhttp.HandlerFor(s.registry.Load(), promhttp.HandlerOpts{
 			DisableCompression: false,
@@ -56,7 +56,7 @@ func (s *scraper) makeHandler() func(http.ResponseWriter, *http.Request) {
 	}
 }
 
-func (s *scraper) decoupled(ctx context.Context, logger *slog.Logger, jobsCfg model.JobsConfig, cache cachingFactory) {
+func (s *Scraper) decoupled(ctx context.Context, logger *slog.Logger, jobsCfg model.JobsConfig, cache cachingFactory) {
 	logger.Debug("Starting scraping async")
 	s.scrape(ctx, logger, jobsCfg, cache)
 
@@ -75,7 +75,7 @@ func (s *scraper) decoupled(ctx context.Context, logger *slog.Logger, jobsCfg mo
 	}
 }
 
-func (s *scraper) scrape(ctx context.Context, logger *slog.Logger, jobsCfg model.JobsConfig, cache cachingFactory) {
+func (s *Scraper) scrape(ctx context.Context, logger *slog.Logger, jobsCfg model.JobsConfig, cache cachingFactory) {
 	if !sem.TryAcquire(1) {
 		// This shouldn't happen under normal use, users should adjust their configuration when this occurs.
 		// Let them know by logging a warning.

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -18,6 +18,7 @@ import (
 	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
+	prom "github.com/prometheus/common/model"
 
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
@@ -182,6 +183,9 @@ func UpdateMetrics(
 	factory clients.Factory,
 	optFuncs ...OptionsFunc,
 ) error {
+	// Use legacy validation as that's the behaviour of former releases.
+	prom.NameValidationScheme = prom.LegacyValidation
+
 	options := defaultOptions()
 	for _, f := range optFuncs {
 		if err := f(&options); err != nil {

--- a/pkg/promutil/prometheus_test.go
+++ b/pkg/promutil/prometheus_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,6 +72,12 @@ func TestSanitize(t *testing.T) {
 }
 
 func TestPromStringTag(t *testing.T) {
+	originalValidationScheme := model.NameValidationScheme
+	model.NameValidationScheme = model.LegacyValidation
+	defer func() {
+		model.NameValidationScheme = originalValidationScheme
+	}()
+
 	testCases := []struct {
 		name        string
 		label       string
@@ -134,6 +141,12 @@ func TestPromStringTag(t *testing.T) {
 }
 
 func TestNewPrometheusCollector_CanReportMetricsAndErrors(t *testing.T) {
+	originalValidationScheme := model.NameValidationScheme
+	model.NameValidationScheme = model.LegacyValidation
+	defer func() {
+		model.NameValidationScheme = originalValidationScheme
+	}()
+
 	metrics := []*PrometheusMetric{
 		{
 			Name:             "this*is*not*valid",


### PR DESCRIPTION
The unit tests weren't running with each PR. This change adds a `test_go` step to the GitHub actions workflow.

Some tests were failing. This is due to a breaking change in Prometheus supporting UTF-8 characters. 

`NameValidationScheme` is set to `LegacyValidation` globally to ensure the behaviour or former releases.