### PR TITLE
use average for cpu utilization to aligns with AWS best practice

### DIFF
--- a/mixin/dashboards/rds.libsonnet
+++ b/mixin/dashboards/rds.libsonnet
@@ -77,7 +77,7 @@ grafana.dashboard.new(
     .addYaxis()
     .addTarget(
       grafana.target.prometheus.new(
-        expr='aws_rds_cpuutilization_maximum{%s}' % [allLabels],
+        expr='aws_rds_cpuutilization_average{%s}' % [allLabels],
         legendFormat='{{dimension_DBInstanceIdentifier}}',
         datasource='$datasource',
       ),

--- a/mixin/dashboards/rds.libsonnet
+++ b/mixin/dashboards/rds.libsonnet
@@ -65,10 +65,10 @@ grafana.dashboard.new(
     .setGridPos(w=24, h=3),
 
     grafana.panel.graph.new(
-      title='CPU utilization',
+      title='CPU utilization average',
       datasource='$datasource',
     )
-    .setGridPos(w=24, h=8)
+    .setGridPos(w=12, h=8)
     .addYaxis(
       format='percent',
       max=100,
@@ -78,6 +78,25 @@ grafana.dashboard.new(
     .addTarget(
       grafana.target.prometheus.new(
         expr='aws_rds_cpuutilization_average{%s}' % [allLabels],
+        legendFormat='{{dimension_DBInstanceIdentifier}}',
+        datasource='$datasource',
+      ),
+    ),
+
+    grafana.panel.graph.new(
+      title='CPU utilization maximum',
+      datasource='$datasource',
+    )
+    .setGridPos(w=12, h=8, x=12)
+    .addYaxis(
+      format='percent',
+      max=100,
+      min=0,
+    )
+    .addYaxis()
+    .addTarget(
+      grafana.target.prometheus.new(
+        expr='aws_rds_cpuutilization_maximum{%s}' % [allLabels],
         legendFormat='{{dimension_DBInstanceIdentifier}}',
         datasource='$datasource',
       ),


### PR DESCRIPTION
Within the **aws-rds** dashboard which rolls with the AWS integration, the first panel (CPU utilization) uses the metric maximum to show utilization:
 
`aws_rds_cpuutilization_maximum`
 
this should use average 
 
`aws_rds_cpuutilization_average`

The justification for this is that average represents a sustained load, is less susceptible to spikes and generally aligns with AWS best practice in terms of auto scaling instances. Max generally should only be used for diagnosing specific issues with a machine. For that reason I think is is useful to have both.

The result will be something like this:
<img width="1704" alt="Screenshot 2025-04-10 at 11 46 52" src="https://github.com/user-attachments/assets/e101985d-be05-46dd-b8ad-7aaa3b7efd4b" />

