### PR TITLE
Add ElasticBeanstalk DimensionRegexp

### DIFF
--- a/examples/lambda_edge.yml
+++ b/examples/lambda_edge.yml
@@ -1,22 +1,22 @@
-  # We can't configure discovery job for edge lambda function but static works.,he region is always us-east-1. 
-  # Other regions can be added in use as edge locations 
-  apiVersion: v1alpha1
-  static:
-    - name: us-east-1.<edge_lambda_function_name>
-      namespace: AWS/Lambda
-      regions:
-        - eu-central-1
-        - us-east-1
-        - us-west-2
-        - ap-southeast-1
-      period: 600
-      length: 600
-      metrics:
-        - name: Invocations
-          statistics: [Sum]
-        - name: Errors
-          statistics: [Sum]
-        - name: Throttles
-          statistics: [Sum]
-        - name: Duration
-          statistics: [Average, Maximum, Minimum, p90]
+  # We can't configure discovery job for edge lambda function but static works.,he region is always us-east-1.
+  # Other regions can be added in use as edge locations
+apiVersion: v1alpha1
+static:
+  - name: us-east-1.<edge_lambda_function_name>
+    namespace: AWS/Lambda
+    regions:
+      - eu-central-1
+      - us-east-1
+      - us-west-2
+      - ap-southeast-1
+    period: 600
+    length: 600
+    metrics:
+      - name: Invocations
+        statistics: [Sum]
+      - name: Errors
+        statistics: [Sum]
+      - name: Throttles
+        statistics: [Sum]
+      - name: Duration
+        statistics: [Average, Maximum, Minimum, p90]

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -211,6 +211,10 @@ var SupportedServices = serviceConfigs{
 		ResourceFilters: []*string{
 			aws.String("elasticbeanstalk:environment"),
 		},
+		DimensionRegexps: []*regexp.Regexp{
+			// arn uses /${ApplicationName}/${EnvironmentName}, but only EnvironmentName is a Metric Dimension
+			regexp.MustCompile("environment/[^/]+/(?P<EnvironmentName>[^/]+)"),
+		},
 	},
 	{
 		Namespace: "AWS/Billing",


### PR DESCRIPTION
- **Add DimensionRegexp to ElasticBeanstalk**
  - We were missing tags on our metrics
- **chore: fix yamllint errors**
  - `make` did complain about this file
