### PR TITLE
feat: add database connections average panel

### DIFF
--- a/mixin/dashboards/rds.libsonnet
+++ b/mixin/dashboards/rds.libsonnet
@@ -103,10 +103,25 @@ grafana.dashboard.new(
     ),
 
     grafana.panel.graph.new(
+      title='Database connections average',
+      datasource='$datasource',
+    )
+    .setGridPos(w=12, h=8)
+    .addYaxis(min=0)
+    .addYaxis()
+    .addTarget(
+      grafana.target.prometheus.new(
+        expr='aws_rds_database_connections_average{%s}' % [allLabels],
+        legendFormat='{{dimension_DBInstanceIdentifier}}',
+        datasource='$datasource',
+      ),
+    ),
+
+    grafana.panel.graph.new(
       title='Database connections count',
       datasource='$datasource',
     )
-    .setGridPos(w=24, h=8)
+    .setGridPos(w=12, h=8, x=12)
     .addYaxis(min=0)
     .addYaxis()
     .addTarget(


### PR DESCRIPTION
add database connections average panel on AWS/RDS dashboard to compare sum vs average performance. 
The RDS dashboard will look like this:

![Screenshot 2025-05-26 at 16 22 05](https://github.com/user-attachments/assets/eecd77cb-c1c0-4417-8240-d178dbd510be)
