### PR TITLE
docs: update URL to Helm Chart

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ See the [docker-compose directory](../docker-compose/README.md).
 
 ### Install with HELM
 
-The official [HELM chart](https://github.com/nerdswords/helm-charts) is the recommended way to install YACE in a Kubernetes cluster.
+The official [HELM chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-yet-another-cloudwatch-exporter) is the recommended way to install YACE in a Kubernetes cluster.
 
 ### Install with manifests
 


### PR DESCRIPTION
The `docs/installation.md` doc contains link to the deprecated Helm Chart: [nerdswords/helm-charts](https://github.com/nerdswords/helm-charts):

> ⚠️ DEPRECATION NOTICE ⚠️ YACE is now part of [prometheus-community](https://github.com/prometheus-community/yet-another-cloudwatch-exporter), the helm chart for new YACE releases has been moved the prometheus-community [helm-charts repo](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-yet-another-cloudwatch-exporter).

I updated the link to the Chart present in [prometheus-community/helm-charts](https://github.com/prometheus-community/helm-charts) repo