### PR TITLE
add AWS/Bedrock GuardrailArn dimension-based resource tagging

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -1039,6 +1039,12 @@ var SupportedServices = serviceConfigs{
 	{
 		Namespace: "AWS/Bedrock",
 		Alias:     "bedrock",
+		ResourceFilters: []*string{
+			aws.String("bedrock:guardrail"),
+		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile("(?P<GuardrailArn>.+)"),
+		},
 	},
 	{
 		Namespace: "AWS/Events",


### PR DESCRIPTION
This PR adds support for `bedrock:guardrail` resources to be mapped to the `GuardrailArn` dimension for `AWS/Bedrock` metrics, per https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-guardrails-cw-metrics.html