### PR TITLE
docs: 1764 add privatelink examples

### DIFF
--- a/examples/private-link-endpoints.yaml
+++ b/examples/private-link-endpoints.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1alpha1
+discovery:
+  jobs:
+    - type: AWS/PrivateLinkEndpoints
+      regions:
+        - us-east-1
+      period: 300
+      length: 300
+      metrics:
+        - name: ActiveConnections
+          statistics: [Average]
+        - name: NewConnections
+          statistics: [Average, Sum]
+        - name: PacketsDropped
+          statistics: [Average, Sum]
+        - name: BytesProcessed
+          statistics: [Sum]

--- a/examples/private-link-services.yaml
+++ b/examples/private-link-services.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1alpha1
+discovery:
+  jobs:
+    - type: AWS/PrivateLinkServices
+      regions:
+        - us-east-1
+      period: 300
+      length: 300
+      metrics:
+        - name: ActiveConnections
+          statistics: [Average]
+        - name: NewConnections
+          statistics: [Average, Sum]
+        - name: PacketsDropped
+          statistics: [Average, Sum]
+        - name: BytesProcessed
+          statistics: [Sum]


### PR DESCRIPTION
Add examples for AWS/PrivateLinkEndpoints and AWS/PrivateLinkServices.

Closes issue #1764 