### PR TITLE
split out Bedrock metrics into all needed namespaces

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -1049,6 +1049,20 @@ var SupportedServices = serviceConfigs{
 	{
 		Namespace: "AWS/Bedrock",
 		Alias:     "bedrock",
+	},
+	{
+		Namespace: "AWS/Bedrock/Agents",
+		Alias:     "bedrock",
+		ResourceFilters: []*string{
+			aws.String("bedrock:agent-alias"),
+		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile("(?P<AgentAliasArn>.+)"),
+		},
+	},
+	{
+		Namespace: "AWS/Bedrock/Guardrails",
+		Alias:     "bedrock",
 		ResourceFilters: []*string{
 			aws.String("bedrock:guardrail"),
 		},


### PR DESCRIPTION
This is a follow on for https://github.com/prometheus-community/yet-another-cloudwatch-exporter/pull/1761 part of https://github.com/grafana/cloud-onboarding/issues/9800

It turns out that AWS/Bedrock is actually split to include two additional sub-namespaces now: AWS/Bedrock/Agents and AWS/Bedrock/Guardrails. I've updated the mapping to account for this.