### PR TITLE
Separate aliases for Bedrock namespaces

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -1052,7 +1052,7 @@ var SupportedServices = serviceConfigs{
 	},
 	{
 		Namespace: "AWS/Bedrock/Agents",
-		Alias:     "bedrock",
+		Alias:     "bedrock-agents",
 		ResourceFilters: []*string{
 			aws.String("bedrock:agent-alias"),
 		},
@@ -1062,7 +1062,7 @@ var SupportedServices = serviceConfigs{
 	},
 	{
 		Namespace: "AWS/Bedrock/Guardrails",
-		Alias:     "bedrock",
+		Alias:     "bedrock-guardrails",
 		ResourceFilters: []*string{
 			aws.String("bedrock:guardrail"),
 		},


### PR DESCRIPTION
Follow on to https://github.com/prometheus-community/yet-another-cloudwatch-exporter/pull/1766, choose separate Alias names for each Bedrock namespace. Part of https://github.com/grafana/cloud-onboarding/issues/9800