### PR TITLE
Add DimensionRegexps support for AWS Backup service

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -147,6 +147,9 @@ var SupportedServices = serviceConfigs{
 		ResourceFilters: []*string{
 			aws.String("backup"),
 		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile(":backup-vault:(?P<BackupVaultName>[^:]+)"),
+		},
 	},
 	{
 		Namespace: "AWS/ApiGateway",


### PR DESCRIPTION
- Add regex pattern to extract BackupVaultName from AWS Backup vault ARNs
- Enables exportedTagsOnMetrics to work with AWS Backup resources
- Pattern matches ARN format: arn:aws:backup:region:account:backup-vault:vault-name