### PR TITLE
Add tests with a VariantName dimension having uppercase value

### DIFF
--- a/pkg/job/maxdimassociator/associator_sagemaker_test.go
+++ b/pkg/job/maxdimassociator/associator_sagemaker_test.go
@@ -171,6 +171,24 @@ func TestAssociatorSagemaker(t *testing.T) {
 			expectedSkip:     false,
 			expectedResource: sagemakerInferenceComponentInvocationUpper,
 		},
+		{
+			name: "variant name match in Upper case",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/SageMaker").ToModelDimensionsRegexp(),
+				resources:        sagemakerInvocationResources,
+				metric: &model.Metric{
+					MetricName: "ModelLatency",
+					Namespace:  "AWS/SageMaker",
+					Dimensions: []model.Dimension{
+						{Name: "EndpointName", Value: "example-endpoint-two"},
+						// this is the important part: VariantName with upper/mixed case
+						{Name: "VariantName", Value: "Variant-One"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: sagemakerEndpointInvocationTwo,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Added two test cases on different levels **without** code changes. This is to show that upper case variant name doesnt affect this part of the code.