### PR TITLE
docs: Fix Docker configuration paths for AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ predict_linear(aws_es_free_storage_space_minimum[2d], 86400 * 7) + on (name) gro
 ## Override AWS endpoint urls
 to support local testing all AWS urls can be overridden with by setting an environment variable `AWS_ENDPOINT_URL`
 ```shell
-docker run -d --rm -v $PWD/credentials:/exporter/.aws/credentials -v $PWD/config.yml:/tmp/config.yml \
+docker run -d --rm -v $PWD/credentials:/home/.aws/credentials -v $PWD/config.yml:/tmp/config.yml \
 -e AWS_ENDPOINT_URL=http://localhost:4766 -p 5000:5000 --name yace quay.io/prometheuscommunity/yet-another-cloudwatch-exporter:latest
 ```
 

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -54,7 +54,7 @@ services:
       - 8080
     volumes:
       - ./yace-config.yaml:/tmp/config.yml
-      - $HOME/.aws:/exporter/.aws:ro
+      - $HOME/.aws:/home/.aws:ro
     command:
       - -listen-address=:8080
       - -config.file=/tmp/config.yml

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ To pull and run the image locally use:
 
 ```shell
 docker run -d --rm \
-  -v $PWD/credentials:/exporter/.aws/credentials \
+  -v $PWD/credentials:/home/.aws/credentials \
   -v $PWD/config.yml:/tmp/config.yml \
   -p 5000:5000 \
   --name yace quay.io/prometheuscommunity/yet-another-cloudwatch-exporter:latest


### PR DESCRIPTION
This PR updates the Docker configuration paths for AWS credentials in the Docker Compose configuration and the documentation.

Fixes:

- https://github.com/prometheus-community/yet-another-cloudwatch-exporter/issues/1757