### PR TITLE
feat: Add DimensionRegexps for AWS/CertificateManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main / (unreleased)
 
+* [ENHANCEMENT] Add DimensionRegexps for AWS/CertificateManager by @vicky-sh-d. #1843
+
 ## 0.64.0 / 2026-03-27
 
 **Important news and breaking changes**

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -109,6 +109,9 @@ var SupportedServices = serviceConfigs{
 		ResourceFilters: []*string{
 			aws.String("acm:certificate"),
 		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile("(?P<CertificateArn>.*)"),
+		},
 	},
 	{
 		Namespace: "AWS/ACMPrivateCA",


### PR DESCRIPTION
AWS/CertificateManager metrics (e.g. DaysToExpiry) are not currently associated with discovered resources because the service configuration is missing DimensionRegexps.

As a result metrics like aws_certificatemanager_days_to_expiry_* do not inherit resource tags

This PR adds a DimensionRegexps entry for AWS/CertificateManager

fixes https://github.com/prometheus-community/yet-another-cloudwatch-exporter/issues/1080