### PR TITLE
feat(ec2): add VPC resource discovery and Per-VPC-Metrics dimension support

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -36,7 +36,9 @@ type ServiceConfig struct {
 	// extract dimensions names from a resource ARN. The regex should
 	// use named groups that correspond to AWS dimensions names.
 	// In cases where the dimension name has a space, it should be
-	// replaced with an underscore (`_`).
+	// replaced with an underscore (`_`). In cases where the dimension
+	// name has a hyphen, it should be replaced with a double underscore
+	// (`__`), as Go regex named groups do not allow hyphens.
 	DimensionRegexps []*regexp.Regexp
 }
 
@@ -49,8 +51,12 @@ func (sc ServiceConfig) ToModelDimensionsRegexp() []model.DimensionsRegexp {
 
 		// skip first name, it's always an empty string
 		for i := 1; i < len(names); i++ {
-			// in the regex names we use underscores where AWS dimensions have spaces
-			dimensionNames = append(dimensionNames, strings.ReplaceAll(names[i], "_", " "))
+			// in the regex names we use double-underscores for hyphens and
+			// single underscores for spaces in AWS dimension names;
+			// double-underscore must be replaced before single-underscore
+			name := strings.ReplaceAll(names[i], "__", "-")
+			name = strings.ReplaceAll(name, "_", " ")
+			dimensionNames = append(dimensionNames, name)
 		}
 
 		dr = append(dr, model.DimensionsRegexp{
@@ -380,9 +386,11 @@ var SupportedServices = serviceConfigs{
 		Alias:     "ec2",
 		ResourceFilters: []*string{
 			aws.String("ec2:instance"),
+			aws.String("ec2:vpc"),
 		},
 		DimensionRegexps: []*regexp.Regexp{
 			regexp.MustCompile("instance/(?P<InstanceId>[^/]+)"),
+			regexp.MustCompile("vpc/(?P<Per__VPC__Metrics>[^/]+)"),
 		},
 	},
 	{

--- a/pkg/config/services_test.go
+++ b/pkg/config/services_test.go
@@ -17,8 +17,47 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/grafana/regexp"
 	"github.com/stretchr/testify/require"
 )
+
+// TestToModelDimensionsRegexpDoubleUnderscoreBecomesHyphen verifies that double
+// underscores in regex named groups are decoded as hyphens in dimension names,
+// allowing dimension names like "Per-VPC-Metrics" to be encoded as
+// "Per__VPC__Metrics" in a Go regex named group.
+func TestToModelDimensionsRegexpDoubleUnderscoreBecomesHyphen(t *testing.T) {
+	sc := ServiceConfig{
+		Namespace: "test",
+		Alias:     "test",
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile("vpc/(?P<Per__VPC__Metrics>[^/]+)"),
+		},
+	}
+	dr := sc.ToModelDimensionsRegexp()
+	require.Len(t, dr, 1)
+	require.Equal(t, []string{"Per-VPC-Metrics"}, dr[0].DimensionsNames)
+}
+
+// TestEC2ServiceConfigIncludesVPC verifies that the AWS/EC2 service config
+// discovers both EC2 instances and VPCs, enabling resolution of VPC-scoped
+// metrics like NetworkAddressUsage that use the Per-VPC-Metrics dimension.
+func TestEC2ServiceConfigIncludesVPC(t *testing.T) {
+	svc := SupportedServices.GetService("AWS/EC2")
+	require.NotNil(t, svc)
+
+	filters := make([]string, 0, len(svc.ResourceFilters))
+	for _, f := range svc.ResourceFilters {
+		filters = append(filters, aws.ToString(f))
+	}
+	require.Contains(t, filters, "ec2:vpc", "expected ec2:vpc in AWS/EC2 ResourceFilters")
+
+	dr := svc.ToModelDimensionsRegexp()
+	var allDimensionNames []string
+	for _, d := range dr {
+		allDimensionNames = append(allDimensionNames, d.DimensionsNames...)
+	}
+	require.Contains(t, allDimensionNames, "Per-VPC-Metrics", "expected 'Per-VPC-Metrics' dimension in AWS/EC2 service config")
+}
 
 func TestSupportedServices(t *testing.T) {
 	for i, svc := range SupportedServices {

--- a/pkg/job/maxdimassociator/associator_ec2_test.go
+++ b/pkg/job/maxdimassociator/associator_ec2_test.go
@@ -32,9 +32,19 @@ var ec2Instance2 = &model.TaggedResource{
 	Namespace: "AWS/EC2",
 }
 
+var ec2VPC1 = &model.TaggedResource{
+	ARN:       "arn:aws:ec2:eu-central-1:123456789012:vpc/vpc-0abc123ef",
+	Namespace: "AWS/EC2",
+	Tags: []model.Tag{
+		{Key: "app", Value: "my-app"},
+		{Key: "env", Value: "dev"},
+	},
+}
+
 var ec2Resources = []*model.TaggedResource{
 	ec2Instance1,
 	ec2Instance2,
+	ec2VPC1,
 }
 
 func TestAssociatorEC2(t *testing.T) {
@@ -114,6 +124,38 @@ func TestAssociatorEC2(t *testing.T) {
 				},
 			},
 			expectedSkip:     false,
+			expectedResource: nil,
+		},
+		{
+			name: "should match VPC resource with Per-VPC-Metrics dimension",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").ToModelDimensionsRegexp(),
+				resources:        ec2Resources,
+				metric: &model.Metric{
+					Namespace:  "AWS/EC2",
+					MetricName: "NetworkAddressUsage",
+					Dimensions: []model.Dimension{
+						{Name: "Per-VPC-Metrics", Value: "vpc-0abc123ef"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: ec2VPC1,
+		},
+		{
+			name: "should skip NetworkAddressUsage metric with unknown VPC ID",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/EC2").ToModelDimensionsRegexp(),
+				resources:        ec2Resources,
+				metric: &model.Metric{
+					Namespace:  "AWS/EC2",
+					MetricName: "NetworkAddressUsage",
+					Dimensions: []model.Dimension{
+						{Name: "Per-VPC-Metrics", Value: "vpc-unknown"},
+					},
+				},
+			},
+			expectedSkip:     true,
 			expectedResource: nil,
 		},
 	}


### PR DESCRIPTION
## Problem

The `AWS/EC2` namespace contains metrics scoped to VPCs rather than EC2 instances, such as `NetworkAddressUsage`, which uses the `Per-VPC-Metrics` dimension (e.g. `Per-VPC-Metrics=vpc-0abc123ef`).

Previously YACE only discovered `ec2:instance` resources for `AWS/EC2` jobs. When CloudWatch returned a metric with a `Per-VPC-Metrics` dimension, the associator found no matching resource and emitted the metric as a global metric with `name="global"` and empty tag labels.

This breaks a common YACE usage pattern: using `searchTags` to scope which resources are monitored, and relying on the resulting tag labels on metrics for routing, filtering, or ingestion control in downstream systems. For VPC-scoped metrics, the tag labels are always empty regardless of how the VPC is tagged in AWS, making this pattern unusable for `NetworkAddressUsage` and any future VPC-level metrics in the `AWS/EC2` namespace.

## Changes

**`pkg/config/services.go`**

- Extends `ToModelDimensionsRegexp()` to decode double-underscore (`__`) as a hyphen (`-`) before decoding single underscore (`_`) as a space. This is necessary because Go regex named groups do not allow hyphens, so `Per-VPC-Metrics` must be encoded as `Per__VPC__Metrics`. The order of replacements matters — `__` must be replaced before `_`.
- Adds `ec2:vpc` to the `AWS/EC2` `ResourceFilters` so VPC resources are queried from the Tagging API.
- Adds a `DimensionRegexp` for VPC ARNs (`vpc/(?P<Per__VPC__Metrics>[^/]+)`) so the associator can match `Per-VPC-Metrics` dimension values against discovered VPC resources.

## Behavior change

For `AWS/EC2` discovery jobs, metrics with a `Per-VPC-Metrics` dimension for a VPC that is **not** in the discovery cache (i.e. not matched by the job's `searchTags`) will now be **skipped** rather than emitted as a global metric. This is consistent with how all other resource types with `DimensionRegexps` behave in YACE.