### PR TITLE
ci: harden actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test_go:
     name: Go tests
@@ -17,6 +20,8 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.26-base
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
       - run: make test
 
@@ -32,6 +37,8 @@ jobs:
         thread: [ 0, 1, 2 ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci/build@42c3c84c865e5c1ab78543b929f7341eb2ef6123 # v0.6.1
         with:
           promu_opts: "-p linux/amd64 -p windows/amd64 -p darwin/amd64 -p linux/arm64 -p windows/arm64 -p darwin/arm64"
@@ -50,6 +57,8 @@ jobs:
         thread: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci/build@42c3c84c865e5c1ab78543b929f7341eb2ef6123 # v0.6.1
         with:
           parallelism: 12
@@ -62,6 +71,8 @@ jobs:
       image: quay.io/prometheus/golang-builder:1.26-base
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - run: make build
       - name: Verify example configs
         run: find ./examples -name "*.yml" -print0 | xargs -0 -I % ./yace verify-config -config.file %
@@ -76,6 +87,8 @@ jobs:
       (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci/publish_main@42c3c84c865e5c1ab78543b929f7341eb2ef6123 # v0.6.1
         with:
           docker_hub_organization: prometheuscommunity
@@ -95,6 +108,8 @@ jobs:
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v0.'))
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: prometheus/promci/publish_release@42c3c84c865e5c1ab78543b929f7341eb2ef6123 # v0.6.1
         with:
           docker_hub_organization: prometheuscommunity


### PR DESCRIPTION
Syncs the GitHub Actions security baseline from `prometheus/prometheus`:

- Workflow-level `permissions: contents: read`
- `persist-credentials: false` on all `actions/checkout` steps

Mirrors upstream prom/prom ([ci.yml](https://github.com/prometheus/prometheus/blob/891e698992754f447ce7efa0ddf5598390ecdd14/.github/workflows/ci.yml) there sets the same workflow-level permissions and applies `persist-credentials: false` on every checkout). No behavior change.