### PR TITLE
fix: downgrade no-resources-found log from ERROR to WARN

### DIFF
--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -64,7 +64,7 @@ func runDiscoveryJob(
 	resources, err := clientTag.GetResources(ctx, job, region)
 	if err != nil {
 		if errors.Is(err, tagging.ErrExpectedToFindResources) {
-			logger.Error("No tagged resources made it through filtering", "err", err)
+			logger.Warn("No tagged resources made it through filtering", "err", err)
 		} else {
 			logger.Error("Couldn't describe resources", "err", err)
 		}


### PR DESCRIPTION
## Summary

Fixes #1688

When a discovery job finds no tagged resources, YACE currently logs at `ERROR` level:

```
{"level":"ERROR","source":"discovery.go:67","msg":"No tagged resources made it through filtering","err":"expected to discover resources but none were found"}
```

This is misleading — it is not a failure. It simply means no AWS resources of that type exist (or are tagged) in the given account/region. This is an expected condition, especially in dev/test accounts where not all services are deployed.

Logging at `ERROR` level causes noise in dashboards and alerting, making it harder to identify real issues.

## Change

Downgrade the log level from `Error` to `Warn` for the `ErrExpectedToFindResources` case. This keeps the signal visible (a job is configured for a service with no matching resources, which may indicate a misconfiguration) without treating it as an operational error.

The other case (`Couldn't describe resources`) remains at `ERROR` as it indicates a genuine failure (e.g. API error, permissions issue).

## Testing

Existing tests cover the `ErrExpectedToFindResources` path. No behaviour change — only log level is affected.