### PR TITLE
pkg/clients: use method-value closures to avoid defeating dead-code elimination

### DIFF
--- a/pkg/clients/account/client.go
+++ b/pkg/clients/account/client.go
@@ -30,21 +30,21 @@ type Client interface {
 }
 
 type client struct {
-	logger    *slog.Logger
-	stsClient *sts.Client
-	iamClient *iam.Client
+	logger             *slog.Logger
+	getCallerIdentity  func(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+	listAccountAliases func(ctx context.Context, params *iam.ListAccountAliasesInput, optFns ...func(*iam.Options)) (*iam.ListAccountAliasesOutput, error)
 }
 
 func NewClient(logger *slog.Logger, stsClient *sts.Client, iamClient *iam.Client) Client {
 	return &client{
-		logger:    logger,
-		stsClient: stsClient,
-		iamClient: iamClient,
+		logger:             logger,
+		getCallerIdentity:  stsClient.GetCallerIdentity,
+		listAccountAliases: iamClient.ListAccountAliases,
 	}
 }
 
 func (c client) GetAccount(ctx context.Context) (string, error) {
-	result, err := c.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	result, err := c.getCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return "", err
 	}
@@ -55,7 +55,7 @@ func (c client) GetAccount(ctx context.Context) (string, error) {
 }
 
 func (c client) GetAccountAlias(ctx context.Context) (string, error) {
-	acctAliasOut, err := c.iamClient.ListAccountAliases(ctx, &iam.ListAccountAliasesInput{})
+	acctAliasOut, err := c.listAccountAliases(ctx, &iam.ListAccountAliasesInput{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/clients/cloudwatch/client.go
+++ b/pkg/clients/cloudwatch/client.go
@@ -50,15 +50,52 @@ type DataPoint struct {
 	Timestamp time.Time
 }
 
+// cloudwatchClientAdapter captures only the CloudWatch operations used by this
+// package as method-value closures, keeping the concrete *aws_cloudwatch.Client
+// out of any interface-reachable struct field so the linker can drop unused
+// operations.
+type cloudwatchClientAdapter struct {
+	listMetrics         func(ctx context.Context, params *aws_cloudwatch.ListMetricsInput, optFns ...func(*aws_cloudwatch.Options)) (*aws_cloudwatch.ListMetricsOutput, error)
+	getMetricData       func(ctx context.Context, params *aws_cloudwatch.GetMetricDataInput, optFns ...func(*aws_cloudwatch.Options)) (*aws_cloudwatch.GetMetricDataOutput, error)
+	getMetricStatistics func(ctx context.Context, params *aws_cloudwatch.GetMetricStatisticsInput, optFns ...func(*aws_cloudwatch.Options)) (*aws_cloudwatch.GetMetricStatisticsOutput, error)
+}
+
+func newCloudwatchClientAdapter(c *aws_cloudwatch.Client) cloudwatchClientAdapter {
+	return cloudwatchClientAdapter{
+		listMetrics:         c.ListMetrics,
+		getMetricData:       c.GetMetricData,
+		getMetricStatistics: c.GetMetricStatistics,
+	}
+}
+
+func (a cloudwatchClientAdapter) ListMetrics(ctx context.Context, params *aws_cloudwatch.ListMetricsInput, optFns ...func(*aws_cloudwatch.Options)) (*aws_cloudwatch.ListMetricsOutput, error) {
+	return a.listMetrics(ctx, params, optFns...)
+}
+
+func (a cloudwatchClientAdapter) GetMetricData(ctx context.Context, params *aws_cloudwatch.GetMetricDataInput, optFns ...func(*aws_cloudwatch.Options)) (*aws_cloudwatch.GetMetricDataOutput, error) {
+	return a.getMetricData(ctx, params, optFns...)
+}
+
+func (a cloudwatchClientAdapter) GetMetricStatistics(ctx context.Context, params *aws_cloudwatch.GetMetricStatisticsInput, optFns ...func(*aws_cloudwatch.Options)) (*aws_cloudwatch.GetMetricStatisticsOutput, error) {
+	return a.getMetricStatistics(ctx, params, optFns...)
+}
+
+// Compile-time checks that the adapter satisfies the interfaces the AWS SDK
+// paginators expect.
+var (
+	_ aws_cloudwatch.ListMetricsAPIClient   = cloudwatchClientAdapter{}
+	_ aws_cloudwatch.GetMetricDataAPIClient = cloudwatchClientAdapter{}
+)
+
 type client struct {
 	logger        *slog.Logger
-	cloudwatchAPI *aws_cloudwatch.Client
+	cloudwatchAPI cloudwatchClientAdapter
 }
 
 func NewClient(logger *slog.Logger, cloudwatchAPI *aws_cloudwatch.Client) Client {
 	return &client{
 		logger:        logger,
-		cloudwatchAPI: cloudwatchAPI,
+		cloudwatchAPI: newCloudwatchClientAdapter(cloudwatchAPI),
 	}
 }
 

--- a/pkg/clients/tagging/adapters.go
+++ b/pkg/clients/tagging/adapters.go
@@ -1,0 +1,176 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tagging
+
+// This file contains closure-based adapters for each AWS SDK client used by the
+// tagging package.  Storing concrete SDK clients (e.g. *ec2.Client) as struct
+// fields on a type that is itself boxed into an interface causes the Go linker
+// to retain every exported method of those clients, defeating dead-code
+// elimination.  Capturing only the used operations as method-value closures
+// keeps the concrete clients out of any interface-reachable struct field, so
+// the linker can drop the unused operations.
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/amp"
+	"github.com/aws/aws-sdk-go-v2/service/apigateway"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go-v2/service/shield"
+	"github.com/aws/aws-sdk-go-v2/service/storagegateway"
+)
+
+// taggingClientAdapter wraps *resourcegroupstaggingapi.Client via closures.
+type taggingClientAdapter struct {
+	getResources func(ctx context.Context, params *resourcegroupstaggingapi.GetResourcesInput, optFns ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error)
+}
+
+func newTaggingClientAdapter(c *resourcegroupstaggingapi.Client) taggingClientAdapter {
+	return taggingClientAdapter{getResources: c.GetResources}
+}
+
+func (a taggingClientAdapter) GetResources(ctx context.Context, params *resourcegroupstaggingapi.GetResourcesInput, optFns ...func(*resourcegroupstaggingapi.Options)) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
+	return a.getResources(ctx, params, optFns...)
+}
+
+// autoscalingClientAdapter wraps *autoscaling.Client via closures.
+type autoscalingClientAdapter struct {
+	describeAutoScalingGroups func(ctx context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
+}
+
+func newAutoscalingClientAdapter(c *autoscaling.Client) autoscalingClientAdapter {
+	return autoscalingClientAdapter{describeAutoScalingGroups: c.DescribeAutoScalingGroups}
+}
+
+func (a autoscalingClientAdapter) DescribeAutoScalingGroups(ctx context.Context, params *autoscaling.DescribeAutoScalingGroupsInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeAutoScalingGroupsOutput, error) {
+	return a.describeAutoScalingGroups(ctx, params, optFns...)
+}
+
+// apiGatewayClientAdapter wraps *apigateway.Client via closures.
+type apiGatewayClientAdapter struct {
+	getRestApis func(ctx context.Context, params *apigateway.GetRestApisInput, optFns ...func(*apigateway.Options)) (*apigateway.GetRestApisOutput, error)
+}
+
+func newAPIGatewayClientAdapter(c *apigateway.Client) apiGatewayClientAdapter {
+	return apiGatewayClientAdapter{getRestApis: c.GetRestApis}
+}
+
+func (a apiGatewayClientAdapter) GetRestApis(ctx context.Context, params *apigateway.GetRestApisInput, optFns ...func(*apigateway.Options)) (*apigateway.GetRestApisOutput, error) {
+	return a.getRestApis(ctx, params, optFns...)
+}
+
+// apiGatewayV2ClientAdapter wraps *apigatewayv2.Client via closures.
+type apiGatewayV2ClientAdapter struct {
+	getApis func(ctx context.Context, params *apigatewayv2.GetApisInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error)
+}
+
+func newAPIGatewayV2ClientAdapter(c *apigatewayv2.Client) apiGatewayV2ClientAdapter {
+	return apiGatewayV2ClientAdapter{getApis: c.GetApis}
+}
+
+func (a apiGatewayV2ClientAdapter) GetApis(ctx context.Context, params *apigatewayv2.GetApisInput, optFns ...func(*apigatewayv2.Options)) (*apigatewayv2.GetApisOutput, error) {
+	return a.getApis(ctx, params, optFns...)
+}
+
+// ec2ClientAdapter wraps *ec2.Client via closures.
+type ec2ClientAdapter struct {
+	describeSpotFleetRequests         func(ctx context.Context, params *ec2.DescribeSpotFleetRequestsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSpotFleetRequestsOutput, error)
+	describeTransitGatewayAttachments func(ctx context.Context, params *ec2.DescribeTransitGatewayAttachmentsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayAttachmentsOutput, error)
+}
+
+func newEC2ClientAdapter(c *ec2.Client) ec2ClientAdapter {
+	return ec2ClientAdapter{
+		describeSpotFleetRequests:         c.DescribeSpotFleetRequests,
+		describeTransitGatewayAttachments: c.DescribeTransitGatewayAttachments,
+	}
+}
+
+func (a ec2ClientAdapter) DescribeSpotFleetRequests(ctx context.Context, params *ec2.DescribeSpotFleetRequestsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSpotFleetRequestsOutput, error) {
+	return a.describeSpotFleetRequests(ctx, params, optFns...)
+}
+
+func (a ec2ClientAdapter) DescribeTransitGatewayAttachments(ctx context.Context, params *ec2.DescribeTransitGatewayAttachmentsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeTransitGatewayAttachmentsOutput, error) {
+	return a.describeTransitGatewayAttachments(ctx, params, optFns...)
+}
+
+// dmsClientAdapter wraps *databasemigrationservice.Client via closures.
+type dmsClientAdapter struct {
+	describeReplicationInstances func(ctx context.Context, params *databasemigrationservice.DescribeReplicationInstancesInput, optFns ...func(*databasemigrationservice.Options)) (*databasemigrationservice.DescribeReplicationInstancesOutput, error)
+	describeReplicationTasks     func(ctx context.Context, params *databasemigrationservice.DescribeReplicationTasksInput, optFns ...func(*databasemigrationservice.Options)) (*databasemigrationservice.DescribeReplicationTasksOutput, error)
+}
+
+func newDMSClientAdapter(c *databasemigrationservice.Client) dmsClientAdapter {
+	return dmsClientAdapter{
+		describeReplicationInstances: c.DescribeReplicationInstances,
+		describeReplicationTasks:     c.DescribeReplicationTasks,
+	}
+}
+
+func (a dmsClientAdapter) DescribeReplicationInstances(ctx context.Context, params *databasemigrationservice.DescribeReplicationInstancesInput, optFns ...func(*databasemigrationservice.Options)) (*databasemigrationservice.DescribeReplicationInstancesOutput, error) {
+	return a.describeReplicationInstances(ctx, params, optFns...)
+}
+
+func (a dmsClientAdapter) DescribeReplicationTasks(ctx context.Context, params *databasemigrationservice.DescribeReplicationTasksInput, optFns ...func(*databasemigrationservice.Options)) (*databasemigrationservice.DescribeReplicationTasksOutput, error) {
+	return a.describeReplicationTasks(ctx, params, optFns...)
+}
+
+// prometheusClientAdapter wraps *amp.Client via closures.
+type prometheusClientAdapter struct {
+	listWorkspaces func(ctx context.Context, params *amp.ListWorkspacesInput, optFns ...func(*amp.Options)) (*amp.ListWorkspacesOutput, error)
+}
+
+func newPrometheusClientAdapter(c *amp.Client) prometheusClientAdapter {
+	return prometheusClientAdapter{listWorkspaces: c.ListWorkspaces}
+}
+
+func (a prometheusClientAdapter) ListWorkspaces(ctx context.Context, params *amp.ListWorkspacesInput, optFns ...func(*amp.Options)) (*amp.ListWorkspacesOutput, error) {
+	return a.listWorkspaces(ctx, params, optFns...)
+}
+
+// storageGatewayClientAdapter wraps *storagegateway.Client via closures.
+type storageGatewayClientAdapter struct {
+	listGateways        func(ctx context.Context, params *storagegateway.ListGatewaysInput, optFns ...func(*storagegateway.Options)) (*storagegateway.ListGatewaysOutput, error)
+	listTagsForResource func(ctx context.Context, params *storagegateway.ListTagsForResourceInput, optFns ...func(*storagegateway.Options)) (*storagegateway.ListTagsForResourceOutput, error)
+}
+
+func newStorageGatewayClientAdapter(c *storagegateway.Client) storageGatewayClientAdapter {
+	return storageGatewayClientAdapter{
+		listGateways:        c.ListGateways,
+		listTagsForResource: c.ListTagsForResource,
+	}
+}
+
+func (a storageGatewayClientAdapter) ListGateways(ctx context.Context, params *storagegateway.ListGatewaysInput, optFns ...func(*storagegateway.Options)) (*storagegateway.ListGatewaysOutput, error) {
+	return a.listGateways(ctx, params, optFns...)
+}
+
+func (a storageGatewayClientAdapter) ListTagsForResource(ctx context.Context, params *storagegateway.ListTagsForResourceInput, optFns ...func(*storagegateway.Options)) (*storagegateway.ListTagsForResourceOutput, error) {
+	return a.listTagsForResource(ctx, params, optFns...)
+}
+
+// shieldClientAdapter wraps *shield.Client via closures.
+type shieldClientAdapter struct {
+	listProtections func(ctx context.Context, params *shield.ListProtectionsInput, optFns ...func(*shield.Options)) (*shield.ListProtectionsOutput, error)
+}
+
+func newShieldClientAdapter(c *shield.Client) shieldClientAdapter {
+	return shieldClientAdapter{listProtections: c.ListProtections}
+}
+
+func (a shieldClientAdapter) ListProtections(ctx context.Context, params *shield.ListProtectionsInput, optFns ...func(*shield.Options)) (*shield.ListProtectionsOutput, error) {
+	return a.listProtections(ctx, params, optFns...)
+}

--- a/pkg/clients/tagging/client.go
+++ b/pkg/clients/tagging/client.go
@@ -35,6 +35,21 @@ import (
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/promutil"
 )
 
+// Compile-time checks that the adapters satisfy the interfaces the AWS SDK
+// paginators expect, catching any signature drift early.
+var (
+	_ resourcegroupstaggingapi.GetResourcesAPIClient                 = taggingClientAdapter{}
+	_ autoscaling.DescribeAutoScalingGroupsAPIClient                 = autoscalingClientAdapter{}
+	_ apigateway.GetRestApisAPIClient                                = apiGatewayClientAdapter{}
+	_ ec2.DescribeSpotFleetRequestsAPIClient                         = ec2ClientAdapter{}
+	_ ec2.DescribeTransitGatewayAttachmentsAPIClient                 = ec2ClientAdapter{}
+	_ databasemigrationservice.DescribeReplicationInstancesAPIClient = dmsClientAdapter{}
+	_ databasemigrationservice.DescribeReplicationTasksAPIClient     = dmsClientAdapter{}
+	_ amp.ListWorkspacesAPIClient                                    = prometheusClientAdapter{}
+	_ storagegateway.ListGatewaysAPIClient                           = storageGatewayClientAdapter{}
+	_ shield.ListProtectionsAPIClient                                = shieldClientAdapter{}
+)
+
 type Client interface {
 	GetResources(ctx context.Context, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error)
 }
@@ -43,15 +58,15 @@ var ErrExpectedToFindResources = errors.New("expected to discover resources but 
 
 type client struct {
 	logger            *slog.Logger
-	taggingAPI        *resourcegroupstaggingapi.Client
-	autoscalingAPI    *autoscaling.Client
-	apiGatewayAPI     *apigateway.Client
-	apiGatewayV2API   *apigatewayv2.Client
-	ec2API            *ec2.Client
-	dmsAPI            *databasemigrationservice.Client
-	prometheusSvcAPI  *amp.Client
-	storageGatewayAPI *storagegateway.Client
-	shieldAPI         *shield.Client
+	taggingAPI        taggingClientAdapter
+	autoscalingAPI    autoscalingClientAdapter
+	apiGatewayAPI     apiGatewayClientAdapter
+	apiGatewayV2API   apiGatewayV2ClientAdapter
+	ec2API            ec2ClientAdapter
+	dmsAPI            dmsClientAdapter
+	prometheusSvcAPI  prometheusClientAdapter
+	storageGatewayAPI storageGatewayClientAdapter
+	shieldAPI         shieldClientAdapter
 }
 
 func NewClient(
@@ -68,15 +83,15 @@ func NewClient(
 ) Client {
 	return &client{
 		logger:            logger,
-		taggingAPI:        taggingAPI,
-		autoscalingAPI:    autoscalingAPI,
-		apiGatewayAPI:     apiGatewayAPI,
-		apiGatewayV2API:   apiGatewayV2API,
-		ec2API:            ec2API,
-		dmsAPI:            dmsClient,
-		prometheusSvcAPI:  prometheusClient,
-		storageGatewayAPI: storageGatewayAPI,
-		shieldAPI:         shieldAPI,
+		taggingAPI:        newTaggingClientAdapter(taggingAPI),
+		autoscalingAPI:    newAutoscalingClientAdapter(autoscalingAPI),
+		apiGatewayAPI:     newAPIGatewayClientAdapter(apiGatewayAPI),
+		apiGatewayV2API:   newAPIGatewayV2ClientAdapter(apiGatewayV2API),
+		ec2API:            newEC2ClientAdapter(ec2API),
+		dmsAPI:            newDMSClientAdapter(dmsClient),
+		prometheusSvcAPI:  newPrometheusClientAdapter(prometheusClient),
+		storageGatewayAPI: newStorageGatewayClientAdapter(storageGatewayAPI),
+		shieldAPI:         newShieldClientAdapter(shieldAPI),
 	}
 }
 

--- a/pkg/clients/tagging/filters_test.go
+++ b/pkg/clients/tagging/filters_test.go
@@ -174,8 +174,8 @@ func TestApiGatewayFilterFunc(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := client{
-				apiGatewayAPI:   tc.apiGatewayAPI,
-				apiGatewayV2API: tc.apiGatewayV2API,
+				apiGatewayAPI:   newAPIGatewayClientAdapter(tc.apiGatewayAPI),
+				apiGatewayV2API: newAPIGatewayV2ClientAdapter(tc.apiGatewayV2API),
 			}
 
 			filter := ServiceFilters["AWS/ApiGateway"]
@@ -299,7 +299,7 @@ func TestDMSFilterFunc(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := client{
-				dmsAPI: tc.dmsAPI,
+				dmsAPI: newDMSClientAdapter(tc.dmsAPI),
 			}
 
 			filter := ServiceFilters["AWS/DMS"]

--- a/pkg/internal/enhancedmetrics/service/dynamodb/client.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/client.go
@@ -22,26 +22,28 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
+// awsClient is kept for test mocking; production code uses method-value closures.
 type awsClient interface {
 	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
 }
 
 // AWSDynamoDBClient wraps the AWS DynamoDB client
 type AWSDynamoDBClient struct {
-	client awsClient
+	describeTableFunc func(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
 }
 
 // NewDynamoDBClientWithConfig creates a new DynamoDB client with custom AWS configuration
 func NewDynamoDBClientWithConfig(cfg aws.Config) Client {
+	c := dynamodb.NewFromConfig(cfg)
 	return &AWSDynamoDBClient{
-		client: dynamodb.NewFromConfig(cfg),
+		describeTableFunc: c.DescribeTable,
 	}
 }
 
 // describeTable retrieves detailed information about a DynamoDB table
 func (c *AWSDynamoDBClient) describeTable(ctx context.Context, tableARN string) (*types.TableDescription, error) {
-	result, err := c.client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
-		// TableName can be either the table name or ARN
+	result, err := c.describeTableFunc(ctx, &dynamodb.DescribeTableInput{
+		// TableName can be either the table name or ARN.
 		TableName: aws.String(tableARN),
 	})
 	if err != nil {

--- a/pkg/internal/enhancedmetrics/service/dynamodb/client_test.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/client_test.go
@@ -82,7 +82,7 @@ func TestAWSDynamoDBClient_DescribeAllTables(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &AWSDynamoDBClient{
-				client: tt.client,
+				describeTableFunc: tt.client.DescribeTable,
 			}
 			got, err := c.DescribeTables(context.Background(), slog.New(slog.DiscardHandler), tt.tables)
 			if (err != nil) != tt.wantErr {

--- a/pkg/internal/enhancedmetrics/service/elasticache/client.go
+++ b/pkg/internal/enhancedmetrics/service/elasticache/client.go
@@ -22,25 +22,27 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 )
 
+// awsClient is kept for test mocking; production code uses method-value closures.
 type awsClient interface {
 	DescribeCacheClusters(ctx context.Context, params *elasticache.DescribeCacheClustersInput, optFns ...func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error)
 }
 
 // AWSElastiCacheClient wraps the AWS ElastiCache client
 type AWSElastiCacheClient struct {
-	client awsClient
+	describeCacheClustersFunc func(ctx context.Context, params *elasticache.DescribeCacheClustersInput, optFns ...func(*elasticache.Options)) (*elasticache.DescribeCacheClustersOutput, error)
 }
 
 // NewElastiCacheClientWithConfig creates a new ElastiCache client with custom AWS configuration
 func NewElastiCacheClientWithConfig(cfg aws.Config) Client {
+	c := elasticache.NewFromConfig(cfg)
 	return &AWSElastiCacheClient{
-		client: elasticache.NewFromConfig(cfg),
+		describeCacheClustersFunc: c.DescribeCacheClusters,
 	}
 }
 
 // describeCacheClusters retrieves information about cache clusters
 func (c *AWSElastiCacheClient) describeCacheClusters(ctx context.Context, input *elasticache.DescribeCacheClustersInput) (*elasticache.DescribeCacheClustersOutput, error) {
-	result, err := c.client.DescribeCacheClusters(ctx, input)
+	result, err := c.describeCacheClustersFunc(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe cache clusters: %w", err)
 	}

--- a/pkg/internal/enhancedmetrics/service/elasticache/client_test.go
+++ b/pkg/internal/enhancedmetrics/service/elasticache/client_test.go
@@ -92,7 +92,7 @@ func TestAWSElastiCacheClient_DescribeAllCacheClusters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &AWSElastiCacheClient{
-				client: tt.client,
+				describeCacheClustersFunc: tt.client.DescribeCacheClusters,
 			}
 			got, err := c.DescribeAllCacheClusters(context.Background(), slog.New(slog.DiscardHandler))
 			if (err != nil) != tt.wantErr {

--- a/pkg/internal/enhancedmetrics/service/lambda/client.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/client.go
@@ -22,25 +22,27 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 )
 
+// awsClient is kept for test mocking; production code uses method-value closures.
 type awsClient interface {
 	ListFunctions(ctx context.Context, params *lambda.ListFunctionsInput, optFns ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error)
 }
 
 // AWSLambdaClient wraps the AWS Lambda client
 type AWSLambdaClient struct {
-	client awsClient
+	listFunctionsFunc func(ctx context.Context, params *lambda.ListFunctionsInput, optFns ...func(*lambda.Options)) (*lambda.ListFunctionsOutput, error)
 }
 
 // NewLambdaClientWithConfig creates a new Lambda client with custom AWS configuration
 func NewLambdaClientWithConfig(cfg aws.Config) Client {
+	c := lambda.NewFromConfig(cfg)
 	return &AWSLambdaClient{
-		client: lambda.NewFromConfig(cfg),
+		listFunctionsFunc: c.ListFunctions,
 	}
 }
 
 // listFunctions retrieves a list of Lambda regionalData
 func (c *AWSLambdaClient) listFunctions(ctx context.Context, input *lambda.ListFunctionsInput) (*lambda.ListFunctionsOutput, error) {
-	result, err := c.client.ListFunctions(ctx, input)
+	result, err := c.listFunctionsFunc(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list Lambda regionalData: %w", err)
 	}

--- a/pkg/internal/enhancedmetrics/service/lambda/client_test.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/client_test.go
@@ -92,7 +92,7 @@ func TestAWSLambdaClient_ListAllFunctions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &AWSLambdaClient{
-				client: tt.client,
+				listFunctionsFunc: tt.client.ListFunctions,
 			}
 			got, err := c.ListAllFunctions(context.Background(), slog.New(slog.DiscardHandler))
 			if (err != nil) != tt.wantErr {

--- a/pkg/internal/enhancedmetrics/service/rds/client.go
+++ b/pkg/internal/enhancedmetrics/service/rds/client.go
@@ -22,25 +22,27 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
 
+// awsClient is kept for test mocking; production code uses method-value closures.
 type awsClient interface {
 	DescribeDBInstances(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
 }
 
 // AWSRDSClient wraps the AWS RDS client
 type AWSRDSClient struct {
-	client awsClient
+	describeDBInstancesFunc func(ctx context.Context, params *rds.DescribeDBInstancesInput, optFns ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error)
 }
 
 // NewRDSClientWithConfig creates a new RDS client with custom AWS configuration
 func NewRDSClientWithConfig(cfg aws.Config) Client {
+	c := rds.NewFromConfig(cfg)
 	return &AWSRDSClient{
-		client: rds.NewFromConfig(cfg),
+		describeDBInstancesFunc: c.DescribeDBInstances,
 	}
 }
 
 // describeDBInstances retrieves information about provisioned RDS instances
 func (c *AWSRDSClient) describeDBInstances(ctx context.Context, input *rds.DescribeDBInstancesInput) (*rds.DescribeDBInstancesOutput, error) {
-	result, err := c.client.DescribeDBInstances(ctx, input)
+	result, err := c.describeDBInstancesFunc(ctx, input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe DB instances: %w", err)
 	}

--- a/pkg/internal/enhancedmetrics/service/rds/client_test.go
+++ b/pkg/internal/enhancedmetrics/service/rds/client_test.go
@@ -105,7 +105,7 @@ func TestAWSRDSClient_DescribeDBInstances(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &AWSRDSClient{
-				client: tt.client,
+				describeDBInstancesFunc: tt.client.DescribeDBInstances,
 			}
 			got, err := c.DescribeDBInstances(context.Background(), slog.New(slog.DiscardHandler), tt.instances)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
Each AWS SDK client (e.g. *ec2.Client) exposes the service's full API — EC2 alone has ~470 operation methods.  When a concrete SDK client is stored as a struct field on a type that is itself boxed into an interface, the Go linker conservatively retains every exported method of that client because reflection could reach them via the interface.

Replace every concrete *X.Client struct field with a closure-based adapter that captures only the operations actually used as method-value closures. The concrete client lives only inside the closure context, which reflection cannot traverse, so the linker drops the unused operations.

Affected packages:
  - pkg/clients/tagging: nine SDK clients wrapped via adapters.go
  - pkg/clients/cloudwatch: cloudwatchClientAdapter with three operations
  - pkg/clients/account: two inline closure fields (STS, IAM)
  - pkg/internal/enhancedmetrics/service/{lambda,elasticache,rds,dynamodb}: each replaces its awsClient interface field with a single function field

No functional or API change; public interfaces and the factory are unchanged. Tests that previously injected mocks via an interface field now pass the mock's method value directly to the closure field.

Binary size (du -h ./yace):
  before: 120M
  after:  29M  (-76%)