### PR TITLE
Add EC2 Capacity Reservations tag discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Only the latest version gets security updates. We won't support older versions.
   * `AWS/DynamoDB` - NoSQL Key-Value Database
   * `AWS/EBS` - Elastic Block Storage
   * `AWS/EC2` - Elastic Compute Cloud
+  * `AWS/EC2CapacityReservations` - EC2 Capacity Reservations
   * `AWS/EC2Spot` - Elastic Compute Cloud for Spot Instances
   * `AWS/ECR` - Elastic Container Registry
   * `AWS/ECS` - Elastic Container Service (Service Metrics)

--- a/examples/ec2-capacity-reservations.yml
+++ b/examples/ec2-capacity-reservations.yml
@@ -1,0 +1,27 @@
+apiVersion: v1alpha1
+discovery:
+  exportedTagsOnMetrics:
+    AWS/EC2CapacityReservations:
+      - Name
+      - Environment
+  jobs:
+    - type: AWS/EC2CapacityReservations
+      regions:
+        - us-east-1
+      searchTags:
+        - key: Environment
+          value: production
+      dimensionNameRequirements:
+        - CapacityReservationId
+      recentlyActiveOnly: true
+      period: 300
+      length: 600
+      metrics:
+        - name: UsedInstanceCount
+          statistics: [Average]
+        - name: AvailableInstanceCount
+          statistics: [Average]
+        - name: TotalInstanceCount
+          statistics: [Average]
+        - name: InstanceUtilization
+          statistics: [Average]

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -398,8 +398,11 @@ var SupportedServices = serviceConfigs{
 	{
 		Namespace: "AWS/EC2CapacityReservations",
 		Alias:     "ec2CapacityReservations",
+		ResourceFilters: []*string{
+			aws.String("ec2:capacity-reservation"),
+		},
 		DimensionRegexps: []*regexp.Regexp{
-			regexp.MustCompile(":capacity-reservation/(?P<CapacityReservationId>)$"),
+			regexp.MustCompile(":capacity-reservation/(?P<CapacityReservationId>[^/]+)$"),
 		},
 	},
 	{

--- a/pkg/config/services_test.go
+++ b/pkg/config/services_test.go
@@ -43,3 +43,18 @@ func TestSupportedServices(t *testing.T) {
 		}
 	}
 }
+
+func TestEC2CapacityReservationsService(t *testing.T) {
+	svc := SupportedServices.GetService("AWS/EC2CapacityReservations")
+	require.NotNil(t, svc)
+	require.Len(t, svc.ResourceFilters, 1)
+	require.Equal(t, "ec2:capacity-reservation", aws.ToString(svc.ResourceFilters[0]))
+
+	dimensionRegexps := svc.ToModelDimensionsRegexp()
+	require.Len(t, dimensionRegexps, 1)
+	require.Equal(t, []string{"CapacityReservationId"}, dimensionRegexps[0].DimensionsNames)
+
+	match := dimensionRegexps[0].Regexp.FindStringSubmatch("arn:aws:ec2:us-east-1:123456789012:capacity-reservation/cr-1234abcd56EXAMPLE")
+	require.Len(t, match, 2)
+	require.Equal(t, "cr-1234abcd56EXAMPLE", match[1])
+}


### PR DESCRIPTION
## Summary
- add Resource Groups Tagging API filter for EC2 Capacity Reservations
- fix CapacityReservationId extraction from capacity reservation ARNs
- add regression coverage and an example discovery config

## Testing
- go test ./pkg/config
- go run ./cmd/yace verify-config -config.file=examples/ec2-capacity-reservations.yml