### PR TITLE
refactor: re-order params for scrapeMetrics to appear just after loggers

### DIFF
--- a/cmd/yace/scraper.go
+++ b/cmd/yace/scraper.go
@@ -68,7 +68,7 @@ func (s *Scraper) makeHandler() func(http.ResponseWriter, *http.Request) {
 }
 
 func (s *Scraper) decoupled(ctx context.Context, logger *slog.Logger, jobsCfg model.JobsConfig, cache cachingFactory) {
-	metricsScraper, err := yacemetrics.NewScraper(logger, s.config, jobsCfg, cache, s.scrapeMetrics)
+	metricsScraper, err := yacemetrics.NewScraper(logger, s.scrapeMetrics, s.config, jobsCfg, cache)
 	if err != nil {
 		logger.Error("invalid runtime scrape configuration", "err", err)
 		return

--- a/pkg/exporter.go
+++ b/pkg/exporter.go
@@ -163,7 +163,7 @@ func BuildPrometheusMetrics(
 		}
 	}
 
-	scraper, err := metrics.NewScraper(logger, configFromOptions(options), jobsCfg, factory, promutil.DeprecatedScrapeMetrics())
+	scraper, err := metrics.NewScraper(logger, promutil.DeprecatedScrapeMetrics(), configFromOptions(options), jobsCfg, factory)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func UpdateMetrics(
 		}
 	}
 
-	scraper, err := metrics.NewScraper(logger, configFromOptions(options), jobsCfg, factory, promutil.DeprecatedScrapeMetrics())
+	scraper, err := metrics.NewScraper(logger, promutil.DeprecatedScrapeMetrics(), configFromOptions(options), jobsCfg, factory)
 	if err != nil {
 		return err
 	}

--- a/pkg/exporter_test.go
+++ b/pkg/exporter_test.go
@@ -247,7 +247,7 @@ func TestMetricsScrape_StaticJob(t *testing.T) {
 
 	registry := prometheus.NewRegistry()
 	// Discard scrape metrics so only the resulting AWS metric lands on the test registry.
-	scraper, err := yacemetrics.NewScraper(logger, config.DefaultConfig(), jobsCfg, factory, promutil.Discard)
+	scraper, err := yacemetrics.NewScraper(logger, promutil.Discard, config.DefaultConfig(), jobsCfg, factory)
 	require.NoError(t, err)
 	metrics, err := scraper.Scrape(ctx)
 	require.NoError(t, err)

--- a/pkg/metrics/build.go
+++ b/pkg/metrics/build.go
@@ -39,10 +39,10 @@ type Scraper struct {
 // Call 'cfg.Validate()' before calling this function.
 func NewScraper(
 	logger *slog.Logger,
+	scrapeMetrics *promutil.ScrapeMetrics,
 	cfg config.Config,
 	jobsCfg model.JobsConfig,
 	factory clients.Factory,
-	scrapeMetrics *promutil.ScrapeMetrics,
 ) (*Scraper, error) {
 	if scrapeMetrics == nil {
 		scrapeMetrics = promutil.Discard
@@ -50,10 +50,10 @@ func NewScraper(
 	cfg.FeatureFlags = append([]string(nil), cfg.FeatureFlags...)
 	return &Scraper{
 		logger:        logger,
+		scrapeMetrics: scrapeMetrics,
 		cfg:           cfg,
 		jobsCfg:       jobsCfg,
 		factory:       factory,
-		scrapeMetrics: scrapeMetrics,
 	}, nil
 }
 


### PR DESCRIPTION
Follow up to https://github.com/prometheus-community/yet-another-cloudwatch-exporter/pull/1857 to reorder the params for `metrics.NewScraper` to consistently put the `scrapeMetrics` after the logger.