### PR TITLE
feat: enhance RDS metrics handling by filtering valid DB instance identifiers from ARNs

### DIFF
--- a/pkg/internal/enhancedmetrics/service/rds/client.go
+++ b/pkg/internal/enhancedmetrics/service/rds/client.go
@@ -49,9 +49,15 @@ func (c *AWSRDSClient) describeDBInstances(ctx context.Context, input *rds.Descr
 	return result, nil
 }
 
-// DescribeDBInstances retrieves all DB instances by handling pagination
+// DescribeDBInstances retrieves the DB instances identified by dbInstances (passed as the
+// "db-instance-id" filter), handling pagination. It returns nil when dbInstances is empty to
+// avoid sending an empty filter to the AWS API.
 func (c *AWSRDSClient) DescribeDBInstances(ctx context.Context, logger *slog.Logger, dbInstances []string) ([]types.DBInstance, error) {
-	logger.Debug("Describing all RDS DB instances")
+	if len(dbInstances) == 0 {
+		return nil, nil
+	}
+
+	logger.Debug("Describing RDS DB instances", slog.Int("requestedInstances", len(dbInstances)))
 	var allInstances []types.DBInstance
 	var marker *string
 	maxRecords := aws.Int32(100)

--- a/pkg/internal/enhancedmetrics/service/rds/client.go
+++ b/pkg/internal/enhancedmetrics/service/rds/client.go
@@ -49,7 +49,7 @@ func (c *AWSRDSClient) describeDBInstances(ctx context.Context, input *rds.Descr
 	return result, nil
 }
 
-// DescribeAllDBInstances retrieves all DB instances by handling pagination
+// DescribeDBInstances retrieves all DB instances by handling pagination
 func (c *AWSRDSClient) DescribeDBInstances(ctx context.Context, logger *slog.Logger, dbInstances []string) ([]types.DBInstance, error) {
 	logger.Debug("Describing all RDS DB instances")
 	var allInstances []types.DBInstance

--- a/pkg/internal/enhancedmetrics/service/rds/client_test.go
+++ b/pkg/internal/enhancedmetrics/service/rds/client_test.go
@@ -92,7 +92,8 @@ func TestAWSRDSClient_DescribeDBInstances(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "error - API failure",
+			name:      "error - API failure",
+			instances: []string{"db-1"},
 			client: &mockRDSClient{
 				describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
 					return nil, fmt.Errorf("API error")
@@ -100,6 +101,17 @@ func TestAWSRDSClient_DescribeDBInstances(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name:      "empty input - no API call",
+			instances: nil,
+			client: &mockRDSClient{
+				describeDBInstancesFunc: func(_ context.Context, _ *rds.DescribeDBInstancesInput, _ ...func(*rds.Options)) (*rds.DescribeDBInstancesOutput, error) {
+					return nil, fmt.Errorf("DescribeDBInstances should not be called for empty input")
+				},
+			},
+			want:    nil,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/internal/enhancedmetrics/service/rds/service.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service.go
@@ -35,13 +35,14 @@ type Client interface {
 }
 
 // dbInstanceIdentifierFromARN extracts the DB instance identifier from an RDS DB instance ARN,
-// whose resource segment has the form "db:<identifier>", e.g.
+// whose resource segment has exactly the form "db:<identifier>", e.g.
 //
 //	arn:aws:rds:eu-west-1:123456789012:db:my-db -> ("my-db", true)
 //
-// It returns ok=false for any other RDS ARN (clusters, etc.): those identifiers are
-// not valid values for the DescribeDBInstances "db-instance-id" filter, which would otherwise
-// reject the whole request. The identifier (not the ARN) is what the filter accepts.
+// It returns ok=false for any other RDS ARN (clusters, etc.) and for malformed ARNs — a missing
+// or empty identifier ("...:db", "...:db:") or extra segments ("...:db:foo:bar"). Those are not
+// valid values for the DescribeDBInstances "db-instance-id" filter, which would otherwise reject
+// the whole request. The identifier (not the ARN) is what the filter accepts.
 func dbInstanceIdentifierFromARN(resourceARN string) (string, bool) {
 	parsed, err := arn.Parse(resourceARN)
 	if err != nil {
@@ -49,7 +50,7 @@ func dbInstanceIdentifierFromARN(resourceARN string) (string, bool) {
 	}
 
 	resourceType, id, found := strings.Cut(parsed.Resource, ":")
-	if !found || resourceType != "db" {
+	if !found || resourceType != "db" || id == "" || strings.Contains(id, ":") {
 		return "", false
 	}
 

--- a/pkg/internal/enhancedmetrics/service/rds/service.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service.go
@@ -39,13 +39,17 @@ type Client interface {
 //
 //	arn:aws:rds:eu-west-1:123456789012:db:my-db -> ("my-db", true)
 //
-// It returns ok=false for any other RDS ARN (clusters, etc.) and for malformed ARNs — a missing
-// or empty identifier ("...:db", "...:db:") or extra segments ("...:db:foo:bar"). Those are not
-// valid values for the DescribeDBInstances "db-instance-id" filter, which would otherwise reject
-// the whole request. The identifier (not the ARN) is what the filter accepts.
+// It returns ok=false for non-RDS ARNs, other RDS ARNs (clusters, etc.), and malformed ARNs —
+// a missing or empty identifier ("...:db", "...:db:") or extra segments ("...:db:foo:bar").
+// Those are not valid values for the DescribeDBInstances "db-instance-id" filter, which would
+// otherwise reject the whole request. The identifier (not the ARN) is what the filter accepts.
 func dbInstanceIdentifierFromARN(resourceARN string) (string, bool) {
 	parsed, err := arn.Parse(resourceARN)
 	if err != nil {
+		return "", false
+	}
+
+	if parsed.Service != "rds" {
 		return "", false
 	}
 

--- a/pkg/internal/enhancedmetrics/service/rds/service.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service.go
@@ -16,9 +16,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/internal/enhancedmetrics/config"
@@ -30,6 +32,28 @@ const awsRdsNamespace = "AWS/RDS"
 
 type Client interface {
 	DescribeDBInstances(ctx context.Context, logger *slog.Logger, dbInstances []string) ([]types.DBInstance, error)
+}
+
+// dbInstanceIdentifierFromARN extracts the DB instance identifier from an RDS DB instance ARN,
+// whose resource segment has the form "db:<identifier>", e.g.
+//
+//	arn:aws:rds:eu-west-1:123456789012:db:my-db -> ("my-db", true)
+//
+// It returns ok=false for any other RDS ARN (clusters, etc.): those identifiers are
+// not valid values for the DescribeDBInstances "db-instance-id" filter, which would otherwise
+// reject the whole request. The identifier (not the ARN) is what the filter accepts.
+func dbInstanceIdentifierFromARN(resourceARN string) (string, bool) {
+	parsed, err := arn.Parse(resourceARN)
+	if err != nil {
+		return "", false
+	}
+
+	resourceType, id, found := strings.Cut(parsed.Resource, ":")
+	if !found || resourceType != "db" {
+		return "", false
+	}
+
+	return id, true
 }
 
 type buildCloudwatchData func(*model.TaggedResource, *types.DBInstance, []string) (*model.CloudwatchData, error)
@@ -76,7 +100,7 @@ func (s *RDS) GetNamespace() string {
 	return awsRdsNamespace
 }
 
-// loadMetricsMetadata loads any metadata needed for RDS enhanced metrics for the given region and role
+// loadMetricsMetadata loads any metadata needed for RDS enhanced metrics for the given region and role.
 func (s *RDS) loadMetricsMetadata(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -93,7 +117,6 @@ func (s *RDS) loadMetricsMetadata(
 	}
 
 	regionalData := make(map[string]*types.DBInstance, len(instances))
-
 	for _, instance := range instances {
 		regionalData[*instance.DBInstanceArn] = &instance
 	}
@@ -111,9 +134,26 @@ func (s *RDS) GetMetrics(ctx context.Context, logger *slog.Logger, resources []*
 		return nil, nil
 	}
 
+	// Only DB instance identifiers (not ARNs) are accepted by the DescribeDBInstances
+	// "db-instance-id" filter. Filter out everything that isn't a supported DB instance up
+	// front (non-instance RDS resources such as clusters and db-proxies, and resources from
+	// another namespace) so their ARNs never reach the API, which would reject the request.
 	dbInstances := make([]string, 0, len(resources))
+	instanceResources := make([]*model.TaggedResource, 0, len(resources))
 	for _, resource := range resources {
-		dbInstances = append(dbInstances, resource.ARN)
+		if resource.Namespace != s.GetNamespace() {
+			logger.Warn("RDS enhanced metrics service cannot process resource with different namespace", "namespace", resource.Namespace, "arn", resource.ARN)
+			continue
+		}
+
+		id, ok := dbInstanceIdentifierFromARN(resource.ARN)
+		if !ok {
+			logger.Warn("Skipping RDS resource: only DB instances are supported", "arn", resource.ARN)
+			continue
+		}
+
+		dbInstances = append(dbInstances, id)
+		instanceResources = append(instanceResources, resource)
 	}
 
 	data, err := s.loadMetricsMetadata(
@@ -130,12 +170,7 @@ func (s *RDS) GetMetrics(ctx context.Context, logger *slog.Logger, resources []*
 
 	var result []*model.CloudwatchData
 
-	for _, resource := range resources {
-		if resource.Namespace != s.GetNamespace() {
-			logger.Warn("RDS enhanced metrics service cannot process resource with different namespace", "namespace", resource.Namespace, "arn", resource.ARN)
-			continue
-		}
-
+	for _, resource := range instanceResources {
 		dbInstance, exists := data[resource.ARN]
 		if !exists {
 			logger.Warn("RDS DB instance not found in metadata", "arn", resource.ARN)

--- a/pkg/internal/enhancedmetrics/service/rds/service.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service.go
@@ -156,6 +156,12 @@ func (s *RDS) GetMetrics(ctx context.Context, logger *slog.Logger, resources []*
 		instanceResources = append(instanceResources, resource)
 	}
 
+	// Nothing supported to describe: avoid calling DescribeDBInstances with an empty
+	// "db-instance-id" filter, which can error or trigger an unintended broad query.
+	if len(dbInstances) == 0 {
+		return nil, nil
+	}
+
 	data, err := s.loadMetricsMetadata(
 		ctx,
 		logger,

--- a/pkg/internal/enhancedmetrics/service/rds/service.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service.go
@@ -117,8 +117,8 @@ func (s *RDS) loadMetricsMetadata(
 	}
 
 	regionalData := make(map[string]*types.DBInstance, len(instances))
-	for _, instance := range instances {
-		regionalData[*instance.DBInstanceArn] = &instance
+	for i := range instances {
+		regionalData[*instances[i].DBInstanceArn] = &instances[i]
 	}
 
 	return regionalData, nil

--- a/pkg/internal/enhancedmetrics/service/rds/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service_test.go
@@ -196,6 +196,8 @@ func TestDBInstanceIdentifierFromARN(t *testing.T) {
 		{"unknown resource type", "arn:aws:rds:eu-west-1:123456789012:og:my-option-group", "", false},
 		{"not an arn", "not-an-arn", "", false},
 		{"arn without resource id", "arn:aws:rds:eu-west-1:123456789012:db", "", false},
+		{"empty identifier", "arn:aws:rds:eu-west-1:123456789012:db:", "", false},
+		{"extra segments", "arn:aws:rds:eu-west-1:123456789012:db:foo:bar", "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/internal/enhancedmetrics/service/rds/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service_test.go
@@ -194,6 +194,7 @@ func TestDBInstanceIdentifierFromARN(t *testing.T) {
 		{"db instance", "arn:aws:rds:eu-west-1:123456789012:db:my-db", "my-db", true},
 		{"db cluster", "arn:aws:rds:eu-west-1:123456789012:cluster:my-aurora", "", false},
 		{"unknown resource type", "arn:aws:rds:eu-west-1:123456789012:og:my-option-group", "", false},
+		{"non-rds service with db segment", "arn:aws:redshift:eu-west-1:123456789012:db:my-db", "", false},
 		{"not an arn", "not-an-arn", "", false},
 		{"arn without resource id", "arn:aws:rds:eu-west-1:123456789012:db", "", false},
 		{"empty identifier", "arn:aws:rds:eu-west-1:123456789012:db:", "", false},

--- a/pkg/internal/enhancedmetrics/service/rds/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/rds/service_test.go
@@ -184,12 +184,87 @@ func TestRDS_GetMetrics(t *testing.T) {
 	}
 }
 
+func TestDBInstanceIdentifierFromARN(t *testing.T) {
+	tests := []struct {
+		name   string
+		arn    string
+		wantID string
+		wantOK bool
+	}{
+		{"db instance", "arn:aws:rds:eu-west-1:123456789012:db:my-db", "my-db", true},
+		{"db cluster", "arn:aws:rds:eu-west-1:123456789012:cluster:my-aurora", "", false},
+		{"unknown resource type", "arn:aws:rds:eu-west-1:123456789012:og:my-option-group", "", false},
+		{"not an arn", "not-an-arn", "", false},
+		{"arn without resource id", "arn:aws:rds:eu-west-1:123456789012:db", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := dbInstanceIdentifierFromARN(tt.arn)
+			require.Equal(t, tt.wantOK, ok)
+			require.Equal(t, tt.wantID, id)
+		})
+	}
+}
+
+// TestRDS_GetMetrics_MixedResources reproduces error 400: a discovery result mixing a
+// DB instance, an Aurora cluster. It asserts that only the DB instance identifier
+// (never an ARN) reaches the filter, the cluster/proxy are skipped, and only the instance metric
+// is produced.
+func TestRDS_GetMetrics_MixedResources(t *testing.T) {
+	const (
+		instanceARN = "arn:aws:rds:eu-west-1:123456789012:db:my-db"
+		clusterARN  = "arn:aws:rds:eu-west-1:123456789012:cluster:my-aurora"
+	)
+
+	mock := &mockServiceRDSClient{
+		instances: []types.DBInstance{{
+			DBInstanceArn:        aws.String(instanceARN),
+			DBInstanceIdentifier: aws.String("my-db"),
+			DBInstanceClass:      aws.String("db.t3.micro"),
+			Engine:               aws.String("postgres"),
+			AllocatedStorage:     aws.Int32(100),
+		}},
+	}
+
+	service := NewRDSService(func(_ aws.Config) Client { return mock })
+
+	resources := []*model.TaggedResource{
+		{ARN: instanceARN, Namespace: awsRdsNamespace},
+		{ARN: clusterARN, Namespace: awsRdsNamespace},
+	}
+
+	result, err := service.GetMetrics(
+		context.Background(),
+		slog.New(slog.DiscardHandler),
+		resources,
+		[]*model.EnhancedMetricConfig{{Name: "AllocatedStorage"}},
+		nil,
+		"eu-west-1",
+		model.Role{},
+		&mockConfigProvider{c: &aws.Config{Region: "eu-west-1"}},
+	)
+	require.NoError(t, err)
+
+	// The filter receives the bare identifier only — never an ARN, and never the cluster/proxy.
+	require.Equal(t, []string{"my-db"}, mock.instanceIDs)
+
+	// Only the DB instance produces a metric; cluster and proxy are skipped.
+	require.Len(t, result, 1)
+	require.Equal(t, awsRdsNamespace, result[0].Namespace)
+	require.Len(t, result[0].GetMetricDataResult.DataPoints, 1)
+	require.Equal(t, 107374182400.0, *result[0].GetMetricDataResult.DataPoints[0].Value) // 100 GiB
+}
+
 type mockServiceRDSClient struct {
 	instances   []types.DBInstance
 	describeErr bool
+
+	// instanceIDs captures the filter input, for assertions.
+	instanceIDs []string
 }
 
-func (m *mockServiceRDSClient) DescribeDBInstances(context.Context, *slog.Logger, []string) ([]types.DBInstance, error) {
+func (m *mockServiceRDSClient) DescribeDBInstances(_ context.Context, _ *slog.Logger, ids []string) ([]types.DBInstance, error) {
+	m.instanceIDs = ids
 	if m.describeErr {
 		return nil, fmt.Errorf("mock describe error")
 	}


### PR DESCRIPTION
This pull request improves the handling of AWS RDS resources in the enhanced metrics service by ensuring that only valid DB instance identifiers (not ARNs or other resource types) are passed to the DescribeDBInstances API. This prevents API errors when non-instance resources (like clusters or proxies) are encountered. The changes also add robust parsing and filtering logic, as well as comprehensive unit tests to cover these scenarios.

**RDS DB Instance Filtering and Identifier Extraction:**

- Added the `dbInstanceIdentifierFromARN` function to reliably extract DB instance identifiers from ARN strings, ensuring only valid DB instances are processed and passed to the DescribeDBInstances filter. This function returns false for unsupported resource types (e.g., clusters) or malformed ARNs.
- Updated the resource filtering logic in `GetMetrics` to:
  - Skip resources not in the RDS namespace.
  - Use the new identifier extraction to filter out unsupported RDS resource types before making API calls.
  - Ensure only DB instance identifiers (not ARNs) are sent to the DescribeDBInstances API, preventing request failures.
 
  
 There is a ticket to add support for other AWS/RDS resource types:
 
 - https://github.com/prometheus-community/yet-another-cloudwatch-exporter/issues/1879 