### PR TITLE
Use default container arch list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 # Needs to be defined before including Makefile.common to auto-generate targets
-DOCKER_ARCHS ?= amd64 armv7 arm64
 DOCKER_REPO  ?= prometheuscommunity
 
 include Makefile.common


### PR DESCRIPTION
The `Makefile.common` now includes a default supported list of container archs.