### PR TITLE
fix: stop mutating global model.NameValidationScheme during scrape

### DIFF
--- a/pkg/metrics/build.go
+++ b/pkg/metrics/build.go
@@ -16,8 +16,6 @@ import (
 	"context"
 	"log/slog"
 
-	prom "github.com/prometheus/common/model"
-
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/config"
@@ -59,9 +57,6 @@ func NewScraper(
 
 // Scrape performs one CloudWatch scrape and converts the result into Prometheus metrics.
 func (s *Scraper) Scrape(ctx context.Context) ([]*promutil.PrometheusMetric, error) {
-	// Use legacy validation as that's the behaviour of former releases.
-	prom.NameValidationScheme = prom.LegacyValidation //nolint:staticcheck
-
 	ctx = config.CtxWithFlags(ctx, featureFlagsMapFromSlice(s.cfg.FeatureFlags))
 
 	tagsData, cloudwatchData := job.ScrapeAwsData(

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -300,7 +300,10 @@ func PromStringTag(text string, labelsSnakeCase bool) (bool, string) {
 	} else {
 		s = sanitize(text)
 	}
-	return model.LabelName(s).IsValid(), s //nolint:staticcheck
+	// Validate against the legacy scheme explicitly instead of reading the
+	// process-global model.NameValidationScheme, which library callers must not
+	// be forced to set or have mutated on their behalf.
+	return model.LegacyValidation.IsValidLabelName(s), s
 }
 
 // sanitize replaces some invalid chars with an underscore

--- a/pkg/promutil/prometheus_test.go
+++ b/pkg/promutil/prometheus_test.go
@@ -116,6 +116,29 @@ func TestPromStringTag(t *testing.T) {
 	}
 }
 
+// TestPromStringTag_IgnoresGlobalValidationScheme guards against regressing to
+// reading the process-global model.NameValidationScheme. PromStringTag must
+// apply legacy label-name rules unconditionally, even when the global is set to
+// UTF8Validation (the prometheus/common default), so that embedding YACE never
+// depends on, nor needs to mutate, that global.
+func TestPromStringTag_IgnoresGlobalValidationScheme(t *testing.T) {
+	originalValidationScheme := model.NameValidationScheme //nolint:staticcheck
+	model.NameValidationScheme = model.UTF8Validation      //nolint:staticcheck
+	defer func() {
+		model.NameValidationScheme = originalValidationScheme //nolint:staticcheck
+	}()
+
+	// "1stLabel" is a valid UTF-8 label name but invalid under legacy rules
+	// (leading digit). It must be rejected regardless of the global scheme.
+	ok, _ := PromStringTag("1stLabel", false)
+	assert.False(t, ok, "leading-digit label must be rejected under legacy rules even when the global scheme is UTF8")
+
+	// A legacy-valid label is still accepted.
+	ok, out := PromStringTag("labelName", false)
+	assert.True(t, ok)
+	assert.Equal(t, "labelName", out)
+}
+
 func TestNewPrometheusCollector_CanReportMetricsAndErrors(t *testing.T) {
 	originalValidationScheme := model.NameValidationScheme //nolint:staticcheck
 	model.NameValidationScheme = model.LegacyValidation    //nolint:staticcheck


### PR DESCRIPTION
Validate label names with `model.LegacyValidation.IsValidLabelName` inline instead of setting the `model.NameValidationScheme` process-global. Should be a backwards compatible change. 

Setting the global can be unsafe when YACE is embedded in other areas. 
