### PR TITLE
feat: extend supported metrics for DynamoDB and Lambda with TableSizeBytes and MemorySize

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -427,7 +427,9 @@ The `enhanced_metrics_config` block allows enabling enhanced metrics for specifi
 Currently supported enhanced metrics are:
 
 - AWS/Lambda (Timeout) - The maximum execution duration permitted for the function before termination.
+- AWS/Lambda (MemorySize) - The amount of memory configured for the function, reported in bytes.
 - AWS/DynamoDB (ItemCount) - The count of items in the table, updated approximately every six hours; may not reflect recent changes.
+- AWS/DynamoDB (TableSizeBytes) - The total size of the table in bytes, updated approximately every six hours; may not reflect recent changes. Per-index sizes are emitted as the `IndexSizeBytes` metric, distinguished by the `GlobalSecondaryIndexName` dimension.
 - AWS/RDS (AllocatedStorage) - The storage capacity in bytes allocated for the DB instance.
 - AWS/ElastiCache (NumCacheNodes) - The count of cache nodes in the cluster; must be 1 for Valkey or Redis OSS clusters, or between 1 and 40 for Memcached clusters.
 

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service.go
@@ -223,7 +223,7 @@ func buildItemCountMetric(resource *model.TaggedResource, table *types.TableDesc
 
 	if len(table.GlobalSecondaryIndexes) > 0 {
 		result = append(result,
-			buildMetricForGlobalSecondaryIndexes(
+			buildGlobalSecondaryIndexesMetricForItemCount(
 				resource,
 				table,
 				exportedTags,
@@ -240,11 +240,9 @@ func buildTableSizeBytesMetric(resource *model.TaggedResource, table *types.Tabl
 		return nil, fmt.Errorf("TableSizeBytes is nil for DynamoDB table %s", resource.ARN)
 	}
 
-	const metricName = "TableSizeBytes"
-
 	value := float64(*table.TableSizeBytes)
 	result := []*model.CloudwatchData{{
-		MetricName:   metricName,
+		MetricName:   "TableSizeBytes",
 		ResourceName: resource.ARN,
 		Namespace:    "AWS/DynamoDB",
 		Dimensions:   getTableDimensions(table),
@@ -261,11 +259,10 @@ func buildTableSizeBytesMetric(resource *model.TaggedResource, table *types.Tabl
 
 	if len(table.GlobalSecondaryIndexes) > 0 {
 		result = append(result,
-			buildMetricForGlobalSecondaryIndexes(
+			buildGlobalSecondaryIndexesMetricForSizeBytes(
 				resource,
 				table,
 				exportedTags,
-				metricName,
 			)...,
 		)
 	}
@@ -273,7 +270,7 @@ func buildTableSizeBytesMetric(resource *model.TaggedResource, table *types.Tabl
 	return result, nil
 }
 
-func buildMetricForGlobalSecondaryIndexes(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string, metricName string) []*model.CloudwatchData {
+func buildGlobalSecondaryIndexesMetricForItemCount(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string, metricName string) []*model.CloudwatchData {
 	var result []*model.CloudwatchData
 
 	for _, globalSecondaryIndex := range table.GlobalSecondaryIndexes {
@@ -308,6 +305,51 @@ func buildMetricForGlobalSecondaryIndexes(resource *model.TaggedResource, table 
 				DataPoints: []model.DataPoint{
 					{
 						Value:     &globalSecondaryIndexesItemsCount,
+						Timestamp: time.Now(),
+					},
+				},
+			},
+		})
+	}
+
+	return result
+}
+
+func buildGlobalSecondaryIndexesMetricForSizeBytes(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string) []*model.CloudwatchData {
+	var result []*model.CloudwatchData
+
+	for _, globalSecondaryIndex := range table.GlobalSecondaryIndexes {
+		if globalSecondaryIndex.IndexSizeBytes == nil || globalSecondaryIndex.IndexName == nil {
+			continue
+		}
+
+		var secondaryIndexesDimensions []model.Dimension
+		globalSecondaryIndexesIndexSizeBytes := float64(*globalSecondaryIndex.IndexSizeBytes)
+
+		if table.TableName != nil {
+			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
+				Name:  "TableName",
+				Value: *table.TableName,
+			})
+		}
+
+		if globalSecondaryIndex.IndexName != nil {
+			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
+				Name:  "GlobalSecondaryIndexName",
+				Value: *globalSecondaryIndex.IndexName,
+			})
+		}
+
+		result = append(result, &model.CloudwatchData{
+			MetricName:   "IndexSizeBytes",
+			ResourceName: resource.ARN,
+			Namespace:    "AWS/DynamoDB",
+			Dimensions:   secondaryIndexesDimensions,
+			Tags:         resource.MetricTags(exportedTags),
+			GetMetricDataResult: &model.GetMetricDataResult{
+				DataPoints: []model.DataPoint{
+					{
+						Value:     &globalSecondaryIndexesIndexSizeBytes,
 						Timestamp: time.Now(),
 					},
 				},

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service.go
@@ -67,8 +67,18 @@ func NewDynamoDBService(buildClientFunc func(cfg aws.Config) Client) *DynamoDB {
 		},
 	}
 
+	// The total size of the table, updated approximately every six hours; may not reflect recent changes.
+	tableSizeBytes := supportedMetric{
+		name:                    "TableSizeBytes",
+		buildCloudwatchDataFunc: buildTableSizeBytesMetric,
+		requiredPermissions: []string{
+			"dynamodb:DescribeTable",
+		},
+	}
+
 	svc.supportedMetrics = map[string]supportedMetric{
 		itemCountMetric.name: itemCountMetric,
+		tableSizeBytes.name:  tableSizeBytes,
 	}
 
 	return svc
@@ -192,20 +202,14 @@ func buildItemCountMetric(resource *model.TaggedResource, table *types.TableDesc
 		return nil, fmt.Errorf("ItemCount is nil for DynamoDB table %s", resource.ARN)
 	}
 
-	var dimensions []model.Dimension
-
-	if table.TableName != nil {
-		dimensions = []model.Dimension{
-			{Name: "TableName", Value: *table.TableName},
-		}
-	}
+	const metricName = "ItemCount"
 
 	value := float64(*table.ItemCount)
 	result := []*model.CloudwatchData{{
-		MetricName:   "ItemCount",
+		MetricName:   metricName,
 		ResourceName: resource.ARN,
 		Namespace:    "AWS/DynamoDB",
-		Dimensions:   dimensions,
+		Dimensions:   getTableDimensions(table),
 		Tags:         resource.MetricTags(exportedTags),
 		GetMetricDataResult: &model.GetMetricDataResult{
 			DataPoints: []model.DataPoint{
@@ -218,45 +222,109 @@ func buildItemCountMetric(resource *model.TaggedResource, table *types.TableDesc
 	}}
 
 	if len(table.GlobalSecondaryIndexes) > 0 {
-		for _, globalSecondaryIndex := range table.GlobalSecondaryIndexes {
-			if globalSecondaryIndex.ItemCount == nil || globalSecondaryIndex.IndexName == nil {
-				continue
-			}
-
-			var secondaryIndexesDimensions []model.Dimension
-			globalSecondaryIndexesItemsCount := float64(*globalSecondaryIndex.ItemCount)
-
-			if table.TableName != nil {
-				secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
-					Name:  "TableName",
-					Value: *table.TableName,
-				})
-			}
-
-			if globalSecondaryIndex.IndexName != nil {
-				secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
-					Name:  "GlobalSecondaryIndexName",
-					Value: *globalSecondaryIndex.IndexName,
-				})
-			}
-
-			result = append(result, &model.CloudwatchData{
-				MetricName:   "ItemCount",
-				ResourceName: resource.ARN,
-				Namespace:    "AWS/DynamoDB",
-				Dimensions:   secondaryIndexesDimensions,
-				Tags:         resource.MetricTags(exportedTags),
-				GetMetricDataResult: &model.GetMetricDataResult{
-					DataPoints: []model.DataPoint{
-						{
-							Value:     &globalSecondaryIndexesItemsCount,
-							Timestamp: time.Now(),
-						},
-					},
-				},
-			})
-		}
+		result = append(result,
+			buildMetricForGlobalSecondaryIndexes(
+				resource,
+				table,
+				exportedTags,
+				metricName,
+			)...,
+		)
 	}
 
 	return result, nil
+}
+
+func buildTableSizeBytesMetric(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string) ([]*model.CloudwatchData, error) {
+	if table.TableSizeBytes == nil {
+		return nil, fmt.Errorf("TableSizeBytes is nil for DynamoDB table %s", resource.ARN)
+	}
+
+	const metricName = "TableSizeBytes"
+
+	value := float64(*table.TableSizeBytes)
+	result := []*model.CloudwatchData{{
+		MetricName:   metricName,
+		ResourceName: resource.ARN,
+		Namespace:    "AWS/DynamoDB",
+		Dimensions:   getTableDimensions(table),
+		Tags:         resource.MetricTags(exportedTags),
+		GetMetricDataResult: &model.GetMetricDataResult{
+			DataPoints: []model.DataPoint{
+				{
+					Value:     &value,
+					Timestamp: time.Now(),
+				},
+			},
+		},
+	}}
+
+	if len(table.GlobalSecondaryIndexes) > 0 {
+		result = append(result,
+			buildMetricForGlobalSecondaryIndexes(
+				resource,
+				table,
+				exportedTags,
+				metricName,
+			)...,
+		)
+	}
+
+	return result, nil
+}
+
+func buildMetricForGlobalSecondaryIndexes(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string, metricName string) []*model.CloudwatchData {
+	var result []*model.CloudwatchData
+
+	for _, globalSecondaryIndex := range table.GlobalSecondaryIndexes {
+		if globalSecondaryIndex.ItemCount == nil || globalSecondaryIndex.IndexName == nil {
+			continue
+		}
+
+		var secondaryIndexesDimensions []model.Dimension
+		globalSecondaryIndexesItemsCount := float64(*globalSecondaryIndex.ItemCount)
+
+		if table.TableName != nil {
+			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
+				Name:  "TableName",
+				Value: *table.TableName,
+			})
+		}
+
+		if globalSecondaryIndex.IndexName != nil {
+			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
+				Name:  "GlobalSecondaryIndexName",
+				Value: *globalSecondaryIndex.IndexName,
+			})
+		}
+
+		result = append(result, &model.CloudwatchData{
+			MetricName:   metricName,
+			ResourceName: resource.ARN,
+			Namespace:    "AWS/DynamoDB",
+			Dimensions:   secondaryIndexesDimensions,
+			Tags:         resource.MetricTags(exportedTags),
+			GetMetricDataResult: &model.GetMetricDataResult{
+				DataPoints: []model.DataPoint{
+					{
+						Value:     &globalSecondaryIndexesItemsCount,
+						Timestamp: time.Now(),
+					},
+				},
+			},
+		})
+	}
+
+	return result
+}
+
+func getTableDimensions(table *types.TableDescription) []model.Dimension {
+	var dimensions []model.Dimension
+
+	if table.TableName != nil {
+		dimensions = []model.Dimension{
+			{Name: "TableName", Value: *table.TableName},
+		}
+	}
+	return dimensions
 }

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -186,6 +187,8 @@ func (s *DynamoDB) ListSupportedEnhancedMetrics() []string {
 	for metric := range s.supportedMetrics {
 		metrics = append(metrics, metric)
 	}
+
+	sort.Strings(metrics)
 	return metrics
 }
 

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service.go
@@ -223,11 +223,12 @@ func buildItemCountMetric(resource *model.TaggedResource, table *types.TableDesc
 
 	if len(table.GlobalSecondaryIndexes) > 0 {
 		result = append(result,
-			buildGlobalSecondaryIndexesMetricForItemCount(
+			buildGlobalSecondaryIndexesMetric(
 				resource,
 				table,
 				exportedTags,
 				metricName,
+				func(gsi types.GlobalSecondaryIndexDescription) *int64 { return gsi.ItemCount },
 			)...,
 		)
 	}
@@ -259,10 +260,12 @@ func buildTableSizeBytesMetric(resource *model.TaggedResource, table *types.Tabl
 
 	if len(table.GlobalSecondaryIndexes) > 0 {
 		result = append(result,
-			buildGlobalSecondaryIndexesMetricForSizeBytes(
+			buildGlobalSecondaryIndexesMetric(
 				resource,
 				table,
 				exportedTags,
+				"IndexSizeBytes",
+				func(gsi types.GlobalSecondaryIndexDescription) *int64 { return gsi.IndexSizeBytes },
 			)...,
 		)
 	}
@@ -270,86 +273,34 @@ func buildTableSizeBytesMetric(resource *model.TaggedResource, table *types.Tabl
 	return result, nil
 }
 
-func buildGlobalSecondaryIndexesMetricForItemCount(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string, metricName string) []*model.CloudwatchData {
+// buildGlobalSecondaryIndexesMetric emits one datapoint per global secondary index for the given
+// metric. getValue selects the source field on the index (e.g. ItemCount or IndexSizeBytes);
+// indexes whose value or name is nil are skipped.
+func buildGlobalSecondaryIndexesMetric(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string, metricName string, getValue func(types.GlobalSecondaryIndexDescription) *int64) []*model.CloudwatchData {
 	var result []*model.CloudwatchData
 
 	for _, globalSecondaryIndex := range table.GlobalSecondaryIndexes {
-		if globalSecondaryIndex.ItemCount == nil || globalSecondaryIndex.IndexName == nil {
+		rawValue := getValue(globalSecondaryIndex)
+		if rawValue == nil || globalSecondaryIndex.IndexName == nil {
 			continue
 		}
 
-		var secondaryIndexesDimensions []model.Dimension
-		globalSecondaryIndexesItemsCount := float64(*globalSecondaryIndex.ItemCount)
-
-		if table.TableName != nil {
-			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
-				Name:  "TableName",
-				Value: *table.TableName,
-			})
-		}
-
-		if globalSecondaryIndex.IndexName != nil {
-			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
-				Name:  "GlobalSecondaryIndexName",
-				Value: *globalSecondaryIndex.IndexName,
-			})
-		}
+		value := float64(*rawValue)
+		dimensions := append(getTableDimensions(table), model.Dimension{
+			Name:  "GlobalSecondaryIndexName",
+			Value: *globalSecondaryIndex.IndexName,
+		})
 
 		result = append(result, &model.CloudwatchData{
 			MetricName:   metricName,
 			ResourceName: resource.ARN,
 			Namespace:    "AWS/DynamoDB",
-			Dimensions:   secondaryIndexesDimensions,
+			Dimensions:   dimensions,
 			Tags:         resource.MetricTags(exportedTags),
 			GetMetricDataResult: &model.GetMetricDataResult{
 				DataPoints: []model.DataPoint{
 					{
-						Value:     &globalSecondaryIndexesItemsCount,
-						Timestamp: time.Now(),
-					},
-				},
-			},
-		})
-	}
-
-	return result
-}
-
-func buildGlobalSecondaryIndexesMetricForSizeBytes(resource *model.TaggedResource, table *types.TableDescription, exportedTags []string) []*model.CloudwatchData {
-	var result []*model.CloudwatchData
-
-	for _, globalSecondaryIndex := range table.GlobalSecondaryIndexes {
-		if globalSecondaryIndex.IndexSizeBytes == nil || globalSecondaryIndex.IndexName == nil {
-			continue
-		}
-
-		var secondaryIndexesDimensions []model.Dimension
-		globalSecondaryIndexesIndexSizeBytes := float64(*globalSecondaryIndex.IndexSizeBytes)
-
-		if table.TableName != nil {
-			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
-				Name:  "TableName",
-				Value: *table.TableName,
-			})
-		}
-
-		if globalSecondaryIndex.IndexName != nil {
-			secondaryIndexesDimensions = append(secondaryIndexesDimensions, model.Dimension{
-				Name:  "GlobalSecondaryIndexName",
-				Value: *globalSecondaryIndex.IndexName,
-			})
-		}
-
-		result = append(result, &model.CloudwatchData{
-			MetricName:   "IndexSizeBytes",
-			ResourceName: resource.ARN,
-			Namespace:    "AWS/DynamoDB",
-			Dimensions:   secondaryIndexesDimensions,
-			Tags:         resource.MetricTags(exportedTags),
-			GetMetricDataResult: &model.GetMetricDataResult{
-				DataPoints: []model.DataPoint{
-					{
-						Value:     &globalSecondaryIndexesIndexSizeBytes,
+						Value:     &value,
 						Timestamp: time.Now(),
 					},
 				},

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
@@ -171,6 +171,28 @@ func TestDynamoDB_GetMetrics(t *testing.T) {
 			wantResultCount: 3, // 1 for table + 2 for GSIs
 		},
 		{
+			name: "successfully received table size bytes metric with global secondary indexes",
+			resources: []*model.TaggedResource{
+				{ARN: "arn:aws:dynamodb:us-east-1:123456789012:table/test-table-with-gsi", Namespace: awsDynamoDBNamespace},
+			},
+			enhancedMetrics: []*model.EnhancedMetricConfig{{Name: "TableSizeBytes"}},
+			tables: []types.TableDescription{
+				{
+					TableArn:       aws.String("arn:aws:dynamodb:us-east-1:123456789012:table/test-table-with-gsi"),
+					TableName:      aws.String("test-table-with-gsi"),
+					TableSizeBytes: aws.Int64(4096),
+					GlobalSecondaryIndexes: []types.GlobalSecondaryIndexDescription{
+						{
+							IndexName:      aws.String("test-gsi-1"),
+							IndexSizeBytes: aws.Int64(1024),
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			wantResultCount: 2, // 1 for table + 1 for GSI
+		},
+		{
 			name: "resource not found in metadata",
 			resources: []*model.TaggedResource{
 				{ARN: "arn:aws:dynamodb:us-east-1:123456789012:table/non-existent"},
@@ -247,8 +269,11 @@ func TestDynamoDB_GetMetrics(t *testing.T) {
 				for _, metric := range result {
 					require.NotNil(t, metric)
 					require.Equal(t, awsDynamoDBNamespace, metric.Namespace)
+					require.NotEmpty(t, metric.MetricName)
 					require.NotEmpty(t, metric.Dimensions)
 					require.NotNil(t, metric.GetMetricDataResult)
+					require.Len(t, metric.GetMetricDataResult.DataPoints, 1)
+					require.NotNil(t, metric.GetMetricDataResult.DataPoints[0].Value)
 					require.Nil(t, metric.GetMetricStatisticsResult)
 				}
 			}

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -79,7 +78,6 @@ func TestDynamoDB_ListSupportedEnhancedMetrics(t *testing.T) {
 		"TableSizeBytes",
 	}
 	supportedMetrics := service.ListSupportedEnhancedMetrics()
-	sort.Strings(supportedMetrics)
 	require.Equal(t, expectedMetrics, supportedMetrics)
 }
 

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
@@ -193,6 +193,30 @@ func TestDynamoDB_GetMetrics(t *testing.T) {
 			wantResultCount: 2, // 1 for table + 1 for GSI
 		},
 		{
+			name: "successfully received multiple metrics with global secondary indexes",
+			resources: []*model.TaggedResource{
+				{ARN: "arn:aws:dynamodb:us-east-1:123456789012:table/test-table-with-gsi", Namespace: awsDynamoDBNamespace},
+			},
+			enhancedMetrics: []*model.EnhancedMetricConfig{{Name: "ItemCount"}, {Name: "TableSizeBytes"}},
+			tables: []types.TableDescription{
+				{
+					TableArn:       aws.String("arn:aws:dynamodb:us-east-1:123456789012:table/test-table-with-gsi"),
+					TableName:      aws.String("test-table-with-gsi"),
+					ItemCount:      aws.Int64(1000),
+					TableSizeBytes: aws.Int64(4096),
+					GlobalSecondaryIndexes: []types.GlobalSecondaryIndexDescription{
+						{
+							IndexName:      aws.String("test-gsi-1"),
+							ItemCount:      aws.Int64(500),
+							IndexSizeBytes: aws.Int64(1024),
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			wantResultCount: 4, // ItemCount: table + GSI; TableSizeBytes: table + GSI
+		},
+		{
 			name: "resource not found in metadata",
 			resources: []*model.TaggedResource{
 				{ARN: "arn:aws:dynamodb:us-east-1:123456789012:table/non-existent"},

--- a/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/dynamodb/service_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -45,8 +46,9 @@ func TestNewDynamoDBService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewDynamoDBService(tt.buildClientFunc)
 			require.NotNil(t, got)
-			require.Len(t, got.supportedMetrics, 1)
+			require.Len(t, got.supportedMetrics, 2)
 			require.NotNil(t, got.supportedMetrics["ItemCount"])
+			require.NotNil(t, got.supportedMetrics["TableSizeBytes"])
 		})
 	}
 }
@@ -63,6 +65,9 @@ func TestDynamoDB_ListRequiredPermissions(t *testing.T) {
 		"ItemCount": {
 			"dynamodb:DescribeTable",
 		},
+		"TableSizeBytes": {
+			"dynamodb:DescribeTable",
+		},
 	}
 	require.Equal(t, expectedPermissions, service.ListRequiredPermissions())
 }
@@ -71,8 +76,11 @@ func TestDynamoDB_ListSupportedEnhancedMetrics(t *testing.T) {
 	service := NewDynamoDBService(nil)
 	expectedMetrics := []string{
 		"ItemCount",
+		"TableSizeBytes",
 	}
-	require.Equal(t, expectedMetrics, service.ListSupportedEnhancedMetrics())
+	supportedMetrics := service.ListSupportedEnhancedMetrics()
+	sort.Strings(supportedMetrics)
+	require.Equal(t, expectedMetrics, supportedMetrics)
 }
 
 func TestDynamoDB_GetMetrics(t *testing.T) {

--- a/pkg/internal/enhancedmetrics/service/lambda/service.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/service.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -167,6 +168,8 @@ func (s *Lambda) ListSupportedEnhancedMetrics() []string {
 	for metric := range s.supportedMetrics {
 		metrics = append(metrics, metric)
 	}
+
+	sort.Strings(metrics)
 	return metrics
 }
 

--- a/pkg/internal/enhancedmetrics/service/lambda/service.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/service.go
@@ -64,8 +64,15 @@ func NewLambdaService(buildClientFunc func(cfg aws.Config) Client) *Lambda {
 		requiredPermissions:     []string{"lambda:ListFunctions"},
 	}
 
+	memorySizeMetric := supportedMetric{
+		name:                    "MemorySize",
+		buildCloudwatchDataFunc: buildMemorySizeMetric,
+		requiredPermissions:     []string{"lambda:ListFunctions"},
+	}
+
 	svc.supportedMetrics = map[string]supportedMetric{
-		timeoutMetric.name: timeoutMetric,
+		timeoutMetric.name:    timeoutMetric,
+		memorySizeMetric.name: memorySizeMetric,
 	}
 
 	return svc
@@ -176,20 +183,12 @@ func buildTimeoutMetric(resource *model.TaggedResource, fn *types.FunctionConfig
 		return nil, fmt.Errorf("timeout is nil for Lambda function %s", resource.ARN)
 	}
 
-	var dimensions []model.Dimension
-
-	if fn.FunctionName != nil {
-		dimensions = []model.Dimension{
-			{Name: "FunctionName", Value: *fn.FunctionName},
-		}
-	}
-
 	value := float64(*fn.Timeout)
 	return &model.CloudwatchData{
 		MetricName:   "Timeout",
 		ResourceName: resource.ARN,
 		Namespace:    "AWS/Lambda",
-		Dimensions:   dimensions,
+		Dimensions:   getFunctionConfigurationDimensions(fn),
 		Tags:         resource.MetricTags(exportedTags),
 		GetMetricDataResult: &model.GetMetricDataResult{
 			DataPoints: []model.DataPoint{
@@ -200,4 +199,39 @@ func buildTimeoutMetric(resource *model.TaggedResource, fn *types.FunctionConfig
 			},
 		},
 	}, nil
+}
+
+func buildMemorySizeMetric(resource *model.TaggedResource, fn *types.FunctionConfiguration, exportedTags []string) (*model.CloudwatchData, error) {
+	if fn.MemorySize == nil {
+		return nil, fmt.Errorf("memorySize is nil for Lambda function %s", resource.ARN)
+	}
+
+	// convert to bytes
+	value := float64(*fn.MemorySize) * 1024 * 1024
+	return &model.CloudwatchData{
+		MetricName:   "MemorySize",
+		ResourceName: resource.ARN,
+		Namespace:    "AWS/Lambda",
+		Dimensions:   getFunctionConfigurationDimensions(fn),
+		Tags:         resource.MetricTags(exportedTags),
+		GetMetricDataResult: &model.GetMetricDataResult{
+			DataPoints: []model.DataPoint{
+				{
+					Value:     &value,
+					Timestamp: time.Now(),
+				},
+			},
+		},
+	}, nil
+}
+
+func getFunctionConfigurationDimensions(fn *types.FunctionConfiguration) []model.Dimension {
+	var dimensions []model.Dimension
+
+	if fn.FunctionName != nil {
+		dimensions = []model.Dimension{
+			{Name: "FunctionName", Value: *fn.FunctionName},
+		}
+	}
+	return dimensions
 }

--- a/pkg/internal/enhancedmetrics/service/lambda/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/service_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -45,8 +46,9 @@ func TestNewLambdaService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := NewLambdaService(tt.buildClientFunc)
 			require.NotNil(t, got)
-			require.Len(t, got.supportedMetrics, 1)
+			require.Len(t, got.supportedMetrics, 2)
 			require.NotNil(t, got.supportedMetrics["Timeout"])
+			require.NotNil(t, got.supportedMetrics["MemorySize"])
 		})
 	}
 }
@@ -60,7 +62,8 @@ func TestLambda_GetNamespace(t *testing.T) {
 func TestLambda_ListRequiredPermissions(t *testing.T) {
 	service := NewLambdaService(nil)
 	expectedPermissions := map[string][]string{
-		"Timeout": {"lambda:ListFunctions"},
+		"Timeout":    {"lambda:ListFunctions"},
+		"MemorySize": {"lambda:ListFunctions"},
 	}
 	require.Equal(t, expectedPermissions, service.ListRequiredPermissions())
 }
@@ -68,9 +71,12 @@ func TestLambda_ListRequiredPermissions(t *testing.T) {
 func TestLambda_ListSupportedEnhancedMetrics(t *testing.T) {
 	service := NewLambdaService(nil)
 	expectedMetrics := []string{
+		"MemorySize",
 		"Timeout",
 	}
-	require.Equal(t, expectedMetrics, service.ListSupportedEnhancedMetrics())
+	supportedMetrics := service.ListSupportedEnhancedMetrics()
+	sort.Strings(supportedMetrics)
+	require.Equal(t, expectedMetrics, supportedMetrics)
 }
 
 func TestLambda_GetMetrics(t *testing.T) {

--- a/pkg/internal/enhancedmetrics/service/lambda/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/service_test.go
@@ -145,6 +145,21 @@ func TestLambda_GetMetrics(t *testing.T) {
 			functions:       []types.FunctionConfiguration{makeFunctionConfiguration("func1", 300), makeFunctionConfiguration("func2", 600)},
 			wantCount:       2,
 		},
+		{
+			name: "successfully received memory size metric",
+			resources: []*model.TaggedResource{
+				{ARN: "arn:aws:lambda:us-east-1:123456789012:function:test-mem", Namespace: awsLambdaNamespace},
+			},
+			enhancedMetrics: []*model.EnhancedMetricConfig{{Name: "MemorySize"}},
+			functions: []types.FunctionConfiguration{
+				{
+					FunctionArn:  aws.String("arn:aws:lambda:us-east-1:123456789012:function:test-mem"),
+					FunctionName: aws.String("test-mem"),
+					MemorySize:   aws.Int32(256),
+				},
+			},
+			wantCount: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -165,8 +180,11 @@ func TestLambda_GetMetrics(t *testing.T) {
 
 			for _, metric := range result {
 				require.Equal(t, awsLambdaNamespace, metric.Namespace)
+				require.NotEmpty(t, metric.MetricName)
 				require.NotEmpty(t, metric.Dimensions)
 				require.NotNil(t, metric.GetMetricDataResult)
+				require.Len(t, metric.GetMetricDataResult.DataPoints, 1)
+				require.NotNil(t, metric.GetMetricDataResult.DataPoints[0].Value)
 			}
 		})
 	}

--- a/pkg/internal/enhancedmetrics/service/lambda/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/service_test.go
@@ -160,6 +160,22 @@ func TestLambda_GetMetrics(t *testing.T) {
 			},
 			wantCount: 1,
 		},
+		{
+			name: "successfully received multiple metrics for a single function",
+			resources: []*model.TaggedResource{
+				{ARN: "arn:aws:lambda:us-east-1:123456789012:function:test-multi", Namespace: awsLambdaNamespace},
+			},
+			enhancedMetrics: []*model.EnhancedMetricConfig{{Name: "Timeout"}, {Name: "MemorySize"}},
+			functions: []types.FunctionConfiguration{
+				{
+					FunctionArn:  aws.String("arn:aws:lambda:us-east-1:123456789012:function:test-multi"),
+					FunctionName: aws.String("test-multi"),
+					Timeout:      aws.Int32(300),
+					MemorySize:   aws.Int32(256),
+				},
+			},
+			wantCount: 2, // 1 for Timeout + 1 for MemorySize
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/internal/enhancedmetrics/service/lambda/service_test.go
+++ b/pkg/internal/enhancedmetrics/service/lambda/service_test.go
@@ -16,7 +16,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -75,7 +74,6 @@ func TestLambda_ListSupportedEnhancedMetrics(t *testing.T) {
 		"Timeout",
 	}
 	supportedMetrics := service.ListSupportedEnhancedMetrics()
-	sort.Strings(supportedMetrics)
 	require.Equal(t, expectedMetrics, supportedMetrics)
 }
 


### PR DESCRIPTION
This pull request adds support for new enhanced metrics for AWS Lambda and DynamoDB services and refactors the code to improve maintainability and test coverage. The main changes include introducing the `MemorySize` metric for Lambda and the `TableSizeBytes` metric for DynamoDB, including per-index size reporting, and updating the documentation and tests accordingly.

Important:

- https://github.com/prometheus-community/yet-another-cloudwatch-exporter/pull/1888/changes#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R432 : selection of the`TableSizeBytes` will also produce `IndexSizeBytes` if possible.  

