### PR TITLE
docs: add RELEASE.md to outline release process and tagging instructions

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -13,4 +13,4 @@
   * add tests relevant to the fixed bug or new feature
 
 ## How to release
-* `git tag v0.13.1-alpha && git push --tags`
+* See [RELEASE.md](RELEASE.md) for the full release process.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,32 @@
+# RELEASE
+
+Releases are tag-triggered: pushing a `vX.Y.Z` tag runs CI, which builds the artifacts and
+publishes them as a **draft** GitHub release that must be manually finalized.
+
+## 1. Prepare the release PR
+
+Bump `VERSION` and add a new section to `CHANGELOG.md`, then open a PR and get it merged to
+`master`.
+
+Example: PR [#1901](https://github.com/prometheus-community/yet-another-cloudwatch-exporter/pull/1901)
+did exactly this.
+
+## 2. Tag and push
+
+Merging the version-bump PR does **not** trigger a release by itself — pushing the tag is what
+triggers the release workflow:
+
+```
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## 3. Wait for CI
+
+Pushing the tag runs the `publish_release` job in `.github/workflows/ci.yml` and creates a **draft** GitHub release.
+
+## 4. Publish the release
+
+Go to the repo's [Releases page](https://github.com/prometheus-community/yet-another-cloudwatch-exporter/releases),
+review the auto-generated draft for `vX.Y.Z`, edit the notes if needed, and click
+**Publish release** to move it out of draft.


### PR DESCRIPTION
This pull request adds documentation outlining the project's release process. The new `RELEASE.md` file explains how releases are triggered, prepared, and finalized.

Release process documentation:

* Added a `RELEASE.md` file that details the steps for preparing a release PR, tagging and pushing a release, waiting for CI to complete, and publishing the release as a finalized GitHub release.