### PR TITLE
feat: add bedrock-mantle namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Only the latest version gets security updates. We won't support older versions.
   * `AWS/AutoScaling` - Auto Scaling Group
   * `AWS/Backup` - Backup
   * `AWS/Bedrock` - GenerativeAI
+  * `AWS/BedrockMantle` - GenerativeAI OpenAI compatible
   * `AWS/Billing` - Billing
   * `AWS/Cassandra` - Cassandra
   * `AWS/CertificateManager` - Certificate Manager

--- a/examples/bedrock-mantle.yml
+++ b/examples/bedrock-mantle.yml
@@ -1,0 +1,24 @@
+apiVersion: v1alpha1
+discovery:
+  jobs:
+    - type: AWS/BedrockMantle
+      regions:
+        - us-east-1
+      period: 600
+      length: 3600
+      metrics:
+        - name: InferenceClientErrors
+          statistics:
+          - Sum
+        - name: TotalInputTokens
+          statistics:
+          - Sum
+        - name: Inferences
+          statistics:
+          - Sum
+        - name: TotalOutputTokens
+          statistics:
+          - Sum
+        - name: InferenceClientErrors
+          statistics:
+          - Sum

--- a/examples/bedrock.yml
+++ b/examples/bedrock.yml
@@ -1,0 +1,24 @@
+apiVersion: v1alpha1
+discovery:
+  jobs:
+    - type: AWS/BedrockMantle
+      regions:
+        - us-east-1
+      period: 600
+      length: 600
+      metrics:
+        - name: InferenceClientErrors
+          statistics:
+          - Sum
+        - name: TotalInputTokens
+          statistics:
+          - Sum
+        - name: Inferences
+          statistics:
+          - Sum
+        - name: TotalOutputTokens
+          statistics:
+          - Sum
+        - name: InferenceClientErrors
+          statistics:
+          - Sum

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -1069,6 +1069,16 @@ var SupportedServices = serviceConfigs{
 		Alias:     "bedrock",
 	},
 	{
+		Namespace: "AWS/BedrockMantle",
+		Alias:     "bedrock-mantle",
+		ResourceFilters: []*string{
+			aws.String("bedrock-mantle:project"),
+		},
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile(":project/(?P<Project>[^/]+)$"),
+		},
+	},
+	{
 		Namespace: "AWS/Bedrock/Agents",
 		Alias:     "bedrock-agents",
 		ResourceFilters: []*string{


### PR DESCRIPTION
This change registers the AWS/BedrockMantle CloudWatch namespace and enables discovery of Mantle project resources