### PR TITLE
Discover AWS/Bedrock application inference profiles for tag/name enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ As a quick start, the following IAM policy can be used to grant the all permissi
         "apigateway:GET",
         "aps:ListWorkspaces",
         "autoscaling:DescribeAutoScalingGroups",
+        "bedrock:ListInferenceProfiles",
+        "bedrock:ListTagsForResource",
         "dms:DescribeReplicationInstances",
         "dms:DescribeReplicationTasks",
         "ec2:DescribeTransitGatewayAttachments",
@@ -209,6 +211,13 @@ This permission is required to discover resources for the AWS/ApiGateway namespa
 This permission is required to discover resources for the AWS/AutoScaling namespace
 ```json
 "autoscaling:DescribeAutoScalingGroups"
+```
+
+These permissions are required to discover resources (application inference profiles) and their
+tags for the AWS/Bedrock namespace
+```json
+"bedrock:ListInferenceProfiles",
+"bedrock:ListTagsForResource"
 ```
 
 These permissions are required to discover resources for the AWS/DMS namespace

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/prometheus-community/yet-another-cloudwatch-exporter
 go 1.25.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.42.1
+	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/config v1.32.30
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.29
 	github.com/aws/aws-sdk-go-v2/service/amp v1.45.2
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.69.1
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.1
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.65.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.60.1
@@ -22,7 +23,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/shield v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.45.2
 	github.com/aws/aws-sdk-go-v2/service/sts v1.44.1
-	github.com/aws/smithy-go v1.27.4
+	github.com/aws/smithy-go v1.27.6
 	github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -41,8 +42,8 @@ require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjH
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
-github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
-github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
+github.com/aws/aws-sdk-go-v2 v1.43.3 h1:XJIcfv8uDs2ukdQsoAC8/Ebu1ejxwzlayl2ZsiFns2A=
+github.com/aws/aws-sdk-go-v2 v1.43.3/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14 h1:3IZY0XAJquT3aHzbkHfPzy4ACPcEjVG0x87KOwtpqGY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.14/go.mod h1:zwM6veDkhGgQFqkBy+uT28AAYpLu+uFMlPl+rCg/73E=
 github.com/aws/aws-sdk-go-v2/config v1.32.30 h1:XwsEzpTJfQYJbFicz/QMLwAZdyeNVVoOEkbF7R3gPJk=
@@ -12,10 +12,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.29 h1:WHZGssHH887cO0ox07SIQZsFx3M
 github.com/aws/aws-sdk-go-v2/credentials v1.19.29/go.mod h1:Mhl0xR6zjguiuj00XRx2wMx22sAltk7oya39sT7fdg8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30 h1:/hi1JADLEW9YYryEz1w4GQu0EtP23pP553Cf9KgsDV4=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.30/go.mod h1:/3AOgy4K17Dm4ucMZVC/MJkzy5kmfKUcINRHZyo0koQ=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 h1:xM/Is9cKMHa8Jj8zkvWhvrFkZsXJV9E+BB4g0HW0duQ=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30/go.mod h1:WueJeNDZvK1fMYEWJIkcivBfEzUkTpBhzlrUKKY8EuA=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJqMqb8hHv31BlLx3ulVqNspUOk=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30/go.mod h1:1hTMsAgbdS/AtUi4bw8+gUuh1pceo+eXRLfpSuSQj3M=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 h1:vuIfjzoeqhQMGJyOBU3t0ZEjn2jrN8Bbg1N4CgjzM5Q=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34/go.mod h1:hP28cN4CPJLZHirdQPrZR50JcLN4ApRJP2tzG8cRlhY=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 h1:9faHsnqxJ1vDvB4wMZy/ajIDyz5QhllQjjc72RJpXAw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34/go.mod h1:Yp6nIyejpa23nzlB/LhT63KTla9Jdi06nv/HH/OkAH8=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1O1b3Erl5CePYIAeQ=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31/go.mod h1:7PuV1yl5e2xnUbm+RqvVg5i2iBM8EyijZNoI9wsOoOc=
 github.com/aws/aws-sdk-go-v2/service/amp v1.45.2 h1:KerxNN65th2ZTKf+wltZgiHOQ9KO2gcEtrpVHrpJ9pY=
@@ -26,6 +26,8 @@ github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.36.1 h1:nkSb00GdOiHUpl07Bd4
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.36.1/go.mod h1:3GU3RMoNjUKXg6GDelv+7bIiJGqk6JXUTmMlvc6+SrU=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.69.1 h1:r3nQYmQYCFjEYAvHGw1HPTu1AkSZVqkWHehdIJnSiZw=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.69.1/go.mod h1:sN7IK8djnxCOQDGVhOvUlIA83i1wIA5jYnzr2TlY9a8=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3 h1:XipaRLJ12/xg+Q2m9K4OkjOrySZuI61HU7bJFVamcNw=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.66.3/go.mod h1:T46juyeeEVRrIMNFhe3P7h7B8bbROERSebRlwPE+K8Q=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.1 h1:KmShXFvPzgolFsYnnDErV+Sj1/orgDaf4tbz+9N+d78=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.63.1/go.mod h1:lipiF9DI3EmTTkEn2sgLug3iEO1dXM50FDFooey6vYU=
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.65.1 h1:WdQFYjLnugfTSJ3fpzrSvefUYcXZyjZeqR0DuDRxK/Q=
@@ -62,8 +64,8 @@ github.com/aws/aws-sdk-go-v2/service/storagegateway v1.45.2 h1:WXZ/I7Q2H6abDIuGR
 github.com/aws/aws-sdk-go-v2/service/storagegateway v1.45.2/go.mod h1:MaL+I3CJyElQoPUXT697xCJhZxxVfvQXfHNvB0bz2p0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.44.1 h1:RvfHDg+xvAeZ+5741vUEjpOVtYSIm93W2zhx10Xtydw=
 github.com/aws/aws-sdk-go-v2/service/sts v1.44.1/go.mod h1:9gdl4RrflIdpDb2TlXshWgR1F9TeCkvqDx77Vpr4Z/Q=
-github.com/aws/smithy-go v1.27.4 h1:JQcphmBN4f0q/sPqXqROIItRNV/hy10cgu7CsFy616M=
-github.com/aws/smithy-go v1.27.4/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.6 h1:0zjT8jgK3jbrTT7JJ3EE6JsMhX8JTrZ+f1sEndYDXrA=
+github.com/aws/smithy-go v1.27.6/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/pkg/clients/factory.go
+++ b/pkg/clients/factory.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -203,6 +204,7 @@ func (c *CachingFactory) GetTaggingClient(region string, role model.Role, concur
 		c.createPrometheusClient(c.clients[role][region].awsConfig),
 		c.createStorageGatewayClient(c.clients[role][region].awsConfig),
 		c.createShieldClient(c.clients[role][region].awsConfig),
+		c.createBedrockClient(c.clients[role][region].awsConfig),
 	)
 	return tagging.NewLimitedConcurrencyClient(client, concurrencyLimit)
 }
@@ -420,6 +422,20 @@ func (c *CachingFactory) createIAMClient(awsConfig *aws.Config) *iam.Client {
 
 func (c *CachingFactory) createShieldClient(awsConfig *aws.Config) *shield.Client {
 	return shield.NewFromConfig(*awsConfig, func(options *shield.Options) {
+		if c.logger != nil && c.logger.Enabled(context.Background(), slog.LevelDebug) {
+			options.ClientLogMode = aws.LogRequestWithBody | aws.LogResponseWithBody
+		}
+		if c.endpointURLOverride != "" {
+			options.BaseEndpoint = aws.String(c.endpointURLOverride)
+		}
+		if c.fipsEnabled {
+			options.EndpointOptions.UseFIPSEndpoint = aws.FIPSEndpointStateEnabled
+		}
+	})
+}
+
+func (c *CachingFactory) createBedrockClient(assumedConfig *aws.Config) *bedrock.Client {
+	return bedrock.NewFromConfig(*assumedConfig, func(options *bedrock.Options) {
 		if c.logger != nil && c.logger.Enabled(context.Background(), slog.LevelDebug) {
 			options.ClientLogMode = aws.LogRequestWithBody | aws.LogResponseWithBody
 		}

--- a/pkg/clients/tagging/adapters.go
+++ b/pkg/clients/tagging/adapters.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
@@ -139,6 +140,27 @@ func newPrometheusClientAdapter(c *amp.Client) prometheusClientAdapter {
 
 func (a prometheusClientAdapter) ListWorkspaces(ctx context.Context, params *amp.ListWorkspacesInput, optFns ...func(*amp.Options)) (*amp.ListWorkspacesOutput, error) {
 	return a.listWorkspaces(ctx, params, optFns...)
+}
+
+// bedrockClientAdapter wraps *bedrock.Client via closures.
+type bedrockClientAdapter struct {
+	listInferenceProfiles func(ctx context.Context, params *bedrock.ListInferenceProfilesInput, optFns ...func(*bedrock.Options)) (*bedrock.ListInferenceProfilesOutput, error)
+	listTagsForResource   func(ctx context.Context, params *bedrock.ListTagsForResourceInput, optFns ...func(*bedrock.Options)) (*bedrock.ListTagsForResourceOutput, error)
+}
+
+func newBedrockClientAdapter(c *bedrock.Client) bedrockClientAdapter {
+	return bedrockClientAdapter{
+		listInferenceProfiles: c.ListInferenceProfiles,
+		listTagsForResource:   c.ListTagsForResource,
+	}
+}
+
+func (a bedrockClientAdapter) ListInferenceProfiles(ctx context.Context, params *bedrock.ListInferenceProfilesInput, optFns ...func(*bedrock.Options)) (*bedrock.ListInferenceProfilesOutput, error) {
+	return a.listInferenceProfiles(ctx, params, optFns...)
+}
+
+func (a bedrockClientAdapter) ListTagsForResource(ctx context.Context, params *bedrock.ListTagsForResourceInput, optFns ...func(*bedrock.Options)) (*bedrock.ListTagsForResourceOutput, error) {
+	return a.listTagsForResource(ctx, params, optFns...)
 }
 
 // storageGatewayClientAdapter wraps *storagegateway.Client via closures.

--- a/pkg/clients/tagging/client.go
+++ b/pkg/clients/tagging/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
@@ -48,6 +49,7 @@ var (
 	_ amp.ListWorkspacesAPIClient                                    = prometheusClientAdapter{}
 	_ storagegateway.ListGatewaysAPIClient                           = storageGatewayClientAdapter{}
 	_ shield.ListProtectionsAPIClient                                = shieldClientAdapter{}
+	_ bedrock.ListInferenceProfilesAPIClient                         = bedrockClientAdapter{}
 )
 
 type Client interface {
@@ -68,6 +70,7 @@ type client struct {
 	prometheusSvcAPI  prometheusClientAdapter
 	storageGatewayAPI storageGatewayClientAdapter
 	shieldAPI         shieldClientAdapter
+	bedrockAPI        bedrockClientAdapter
 }
 
 func NewClient(
@@ -82,6 +85,7 @@ func NewClient(
 	prometheusClient *amp.Client,
 	storageGatewayAPI *storagegateway.Client,
 	shieldAPI *shield.Client,
+	bedrockAPI *bedrock.Client,
 ) Client {
 	if scrapeMetrics == nil {
 		scrapeMetrics = promutil.Discard
@@ -98,6 +102,7 @@ func NewClient(
 		prometheusSvcAPI:  newPrometheusClientAdapter(prometheusClient),
 		storageGatewayAPI: newStorageGatewayClientAdapter(storageGatewayAPI),
 		shieldAPI:         newShieldClientAdapter(shieldAPI),
+		bedrockAPI:        newBedrockClientAdapter(bedrockAPI),
 	}
 }
 

--- a/pkg/clients/tagging/filters.go
+++ b/pkg/clients/tagging/filters.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/shield"
@@ -125,6 +126,62 @@ var ServiceFilters = map[string]ServiceFilter{
 
 					for _, t := range asg.Tags {
 						resource.Tags = append(resource.Tags, model.Tag{Key: *t.Key, Value: *t.Value})
+					}
+
+					if resource.FilterThroughTags(job.SearchTags) {
+						resources = append(resources, &resource)
+					}
+				}
+			}
+
+			return resources, nil
+		},
+	},
+	"AWS/Bedrock": {
+		// Bedrock application inference profiles aren't discoverable via the tagging API in a
+		// way that also surfaces the profile's human-readable name, so ListInferenceProfiles is
+		// used directly here instead. The profile's InferenceProfileId is what CloudWatch's
+		// ModelId dimension is set to for these resources (not the ARN), so the ARN field here
+		// is repurposed - like AWS/StorageGateway does - to carry "<id>/<name>" instead of the
+		// real ARN. This lets the ModelId dimension regex (see pkg/config/services.go) match the
+		// id prefix, while the profile name still ends up in the metric's "name" label.
+		ResourceFunc: func(ctx context.Context, client client, job model.DiscoveryJob, region string) ([]*model.TaggedResource, error) {
+			const maxPages = 100
+			pageNum := 0
+
+			var resources []*model.TaggedResource
+			paginator := bedrock.NewListInferenceProfilesPaginator(client.bedrockAPI, &bedrock.ListInferenceProfilesInput{}, func(options *bedrock.ListInferenceProfilesPaginatorOptions) {
+				options.StopOnDuplicateToken = true
+			})
+
+			for paginator.HasMorePages() && pageNum < maxPages {
+				page, err := paginator.NextPage(ctx)
+				client.scrapeMetrics.BedrockAPICounter.Inc()
+				if err != nil {
+					return nil, fmt.Errorf("error calling bedrockAPI.ListInferenceProfiles, %w", err)
+				}
+				pageNum++
+
+				for _, profile := range page.InferenceProfileSummaries {
+					resource := model.TaggedResource{
+						ARN:       fmt.Sprintf("%s/%s", *profile.InferenceProfileId, *profile.InferenceProfileName),
+						Namespace: job.Namespace,
+						Region:    region,
+					}
+
+					tagsRequest := &bedrock.ListTagsForResourceInput{
+						ResourceARN: profile.InferenceProfileArn,
+					}
+					// System-defined profiles are owned by AWS rather than the caller's account and
+					// don't support tagging, so ListTagsForResource is expected to fail for them.
+					// Treat that as "no tags" instead of aborting discovery for the whole namespace.
+					tagsResponse, err := client.bedrockAPI.ListTagsForResource(ctx, tagsRequest)
+					client.scrapeMetrics.BedrockAPICounter.Inc()
+
+					if err == nil {
+						for _, t := range tagsResponse.Tags {
+							resource.Tags = append(resource.Tags, model.Tag{Key: *t.Key, Value: *t.Value})
+						}
 					}
 
 					if resource.FilterThroughTags(job.SearchTags) {

--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -1065,8 +1065,15 @@ var SupportedServices = serviceConfigs{
 		},
 	},
 	{
+		// Resources for this namespace are discovered via a ServiceFilter ResourceFunc
+		// (see pkg/clients/tagging/filters.go) rather than ResourceFilters, because
+		// application inference profiles aren't returned by the tagging API in a way
+		// that also carries the profile's human-readable name.
 		Namespace: "AWS/Bedrock",
 		Alias:     "bedrock",
+		DimensionRegexps: []*regexp.Regexp{
+			regexp.MustCompile("^(?P<ModelId>[^/]+)/"),
+		},
 	},
 	{
 		Namespace: "AWS/Bedrock/Agents",

--- a/pkg/job/maxdimassociator/associator_bedrock_test.go
+++ b/pkg/job/maxdimassociator/associator_bedrock_test.go
@@ -1,0 +1,91 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package maxdimassociator
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/promslog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/config"
+	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/model"
+)
+
+var bedrockApplicationInferenceProfile = &model.TaggedResource{
+	ARN:       "p152fiotth4d/var-review-agent",
+	Namespace: "AWS/Bedrock",
+}
+
+var bedrockResources = []*model.TaggedResource{
+	bedrockApplicationInferenceProfile,
+}
+
+func TestAssociatorBedrock(t *testing.T) {
+	type args struct {
+		dimensionRegexps []model.DimensionsRegexp
+		resources        []*model.TaggedResource
+		metric           *model.Metric
+	}
+
+	type testCase struct {
+		name             string
+		args             args
+		expectedSkip     bool
+		expectedResource *model.TaggedResource
+	}
+
+	testcases := []testCase{
+		{
+			name: "should match application inference profile with ModelId dimension",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Bedrock").ToModelDimensionsRegexp(),
+				resources:        bedrockResources,
+				metric: &model.Metric{
+					MetricName: "InputTokenCount",
+					Namespace:  "AWS/Bedrock",
+					Dimensions: []model.Dimension{
+						{Name: "ModelId", Value: "p152fiotth4d"},
+					},
+				},
+			},
+			expectedSkip:     false,
+			expectedResource: bedrockApplicationInferenceProfile,
+		},
+		{
+			name: "should skip foundation model ModelId not backed by a tagged resource",
+			args: args{
+				dimensionRegexps: config.SupportedServices.GetService("AWS/Bedrock").ToModelDimensionsRegexp(),
+				resources:        bedrockResources,
+				metric: &model.Metric{
+					MetricName: "InputTokenCount",
+					Namespace:  "AWS/Bedrock",
+					Dimensions: []model.Dimension{
+						{Name: "ModelId", Value: "anthropic.claude-3-haiku-20240307-v1:0"},
+					},
+				},
+			},
+			expectedSkip:     true,
+			expectedResource: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			associator := NewAssociator(promslog.NewNopLogger(), tc.args.dimensionRegexps, tc.args.resources)
+			res, skip := associator.AssociateMetricToResource(tc.args.metric)
+			require.Equal(t, tc.expectedSkip, skip)
+			require.Equal(t, tc.expectedResource, res)
+		})
+	}
+}

--- a/pkg/promutil/prometheus.go
+++ b/pkg/promutil/prometheus.go
@@ -60,6 +60,7 @@ type ScrapeMetrics struct {
 	ManagedPrometheusAPICounter              Counter
 	StoragegatewayAPICounter                 Counter
 	DmsAPICounter                            Counter
+	BedrockAPICounter                        Counter
 	DuplicateMetricsFilteredCounter          Counter
 }
 
@@ -128,6 +129,10 @@ func NewScrapeMetrics(r prometheus.Registerer) *ScrapeMetrics {
 			Name: "yace_cloudwatch_dmsapi_requests_total",
 			Help: "Help is not implemented yet.",
 		})},
+		BedrockAPICounter: Counter{inner: f.NewCounter(prometheus.CounterOpts{
+			Name: "yace_cloudwatch_bedrockapi_requests_total",
+			Help: "Help is not implemented yet.",
+		})},
 		DuplicateMetricsFilteredCounter: Counter{inner: f.NewCounter(prometheus.CounterOpts{
 			Name: "yace_cloudwatch_duplicate_metrics_filtered",
 			Help: "Help is not implemented yet.",
@@ -160,6 +165,7 @@ func (m *ScrapeMetrics) Collectors() []prometheus.Collector {
 		m.ManagedPrometheusAPICounter,
 		m.StoragegatewayAPICounter,
 		m.DmsAPICounter,
+		m.BedrockAPICounter,
 		m.DuplicateMetricsFilteredCounter,
 	}
 	out := make([]prometheus.Collector, 0, len(vecs)+len(counters))


### PR DESCRIPTION
## Summary

`AWS/Bedrock` has no `ResourceFilters` entry in `pkg/config/services.go`, so the tagging client's `resourcegroupstaggingapi`-based discovery (`pkg/clients/tagging/client.go`) never runs for it (`if len(svc.ResourceFilters) > 0`). As a result, `AWS/Bedrock` metrics are always emitted with:

- Empty `tag_*` labels, regardless of `exportedTagsOnMetrics` configuration
- A `name="global"` label, since no resource is ever associated to the metric

This is easy to reproduce: configure `exportedTagsOnMetrics.AWS/Bedrock` with any tag key, scrape `AWS/Bedrock` metrics, and the resulting `tag_*` label value is always `""`.

Unlike most namespaces, Bedrock application inference profile tags aren't reliably obtainable through the tagging API in a way that also carries the profile's human-readable name (`InferenceProfileName`), which isn't part of the ARN. So instead of adding `ResourceFilters`, this PR adds a dedicated `ServiceFilter` (see the existing `AWS/StorageGateway` entry for precedent) that:

- Calls `bedrock:ListInferenceProfiles` directly to discover inference profiles
- Calls `bedrock:ListTagsForResource` per profile to fetch tags (best-effort: `SYSTEM_DEFINED` profiles are AWS-owned and don't support tagging, so a failed call is treated as "no tags" rather than aborting discovery)
- Sets the resource's `ARN` field to `"<profile-id>/<profile-name>"` instead of the real ARN (same trick `AWS/StorageGateway` uses with `"<gateway-id>/<gateway-name>"`), since CloudWatch's `ModelId` dimension for these metrics is the bare profile ID, not the full ARN. This lets the `ModelId` dimension regex match the id prefix while the profile's name still ends up in the metric's `name` label instead of `"global"`.

## Changes

- `pkg/config/services.go`: drop `ResourceFilters` from `AWS/Bedrock`, update the `DimensionRegexps` entry to match the new `<id>/<name>` scheme
- `pkg/clients/tagging/filters.go`: add a `ServiceFilter` for `AWS/Bedrock`
- `pkg/clients/tagging/adapters.go`, `client.go`: wire up a `bedrock` client adapter, following the existing closure-based adapter pattern
- `pkg/clients/factory.go`: construct the `*bedrock.Client`
- `pkg/promutil/prometheus.go`: add `BedrockAPICounter` scrape metric
- `pkg/job/maxdimassociator/associator_bedrock_test.go`: new associator test covering the match/skip cases
- `README.md`: document the new `bedrock:ListInferenceProfiles` / `bedrock:ListTagsForResource` IAM permissions
- `go.mod`/`go.sum`: add `github.com/aws/aws-sdk-go-v2/service/bedrock` (minor patch bumps to `aws-sdk-go-v2` core and `smithy-go` came along via `go mod tidy`)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] Verified against a real account: the previously-broken `tag_app` label (added via `exportedTagsOnMetrics`) and `name` label are both populated correctly once this discovery path runs