### PR TITLE
Add -disable-account-alias-lookup flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ The AWS IAM API supports creating account aliases, which are human-friendly name
 "iam:ListAccountAliases"
 ```
 
+This call can be disabled with `-disable-account-alias-lookup` if the alias is not needed or the IAM endpoint is not reachable.
+
 If running YACE inside an AWS EC2 instance, the exporter will automatically attempt to assume the associated IAM Role. If this is undesirable behavior turn off the use the metadata endpoint by setting the environment variable `AWS_EC2_METADATA_DISABLED=true`.
 
 ## Configuration

--- a/cmd/yace/main.go
+++ b/cmd/yace/main.go
@@ -54,17 +54,18 @@ const (
 )
 
 var (
-	addr                  string
-	configFile            string
-	logLevel              string
-	logFormat             string
-	fips                  bool
-	cloudwatchConcurrency config.CloudWatchConcurrencyConfig
-	tagConcurrency        int
-	scrapingInterval      int
-	metricsPerQuery       int
-	labelsSnakeCase       bool
-	profilingEnabled      bool
+	addr                      string
+	configFile                string
+	logLevel                  string
+	logFormat                  string
+	fips                      bool
+	disableAccountAliasLookup bool
+	cloudwatchConcurrency     config.CloudWatchConcurrencyConfig
+	tagConcurrency            int
+	scrapingInterval          int
+	metricsPerQuery           int
+	labelsSnakeCase           bool
+	profilingEnabled          bool
 
 	logger *slog.Logger
 )
@@ -138,6 +139,12 @@ func NewYACEApp() *cli.App {
 			Value:       false,
 			Usage:       "Use FIPS compliant AWS API endpoints",
 			Destination: &fips,
+		},
+		&cli.BoolFlag{
+			Name:        "disable-account-alias-lookup",
+			Value:       false,
+			Usage:       "Disable the IAM ListAccountAliases call. The account_alias label on metrics will be empty.",
+			Destination: &disableAccountAliasLookup,
 		},
 		&cli.IntFlag{
 			Name:        "cloudwatch-concurrency",
@@ -262,6 +269,7 @@ func startScraper(c *cli.Context) error {
 	cfg.TaggingAPIConcurrency = tagConcurrency
 	cfg.FeatureFlags = c.StringSlice(enableFeatureFlag)
 	cfg.FIPSEnabled = fips
+	cfg.DisableAccountAliasLookup = disableAccountAliasLookup
 	cfg.CloudwatchConcurrency = cloudwatchConcurrency
 	if err := cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid runtime scrape configuration: %w", err)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ All flags may be prefixed with either one hypen or two (i.e., both `-config.file
 | `-log.format` | Output format of log messages. One of: [logfmt, json] | `json` |
 | `-log.level` | Log at selected level. One of: [debug, info, warn, error] | `info` |
 | `-fips` | Use FIPS compliant AWS API | `false` |
+| `-disable-account-alias-lookup` | Disable the IAM `ListAccountAliases` API call. The `account_alias` label will be empty. | `false` |
 | `-cloudwatch-concurrency` | Maximum number of concurrent requests to CloudWatch API | `5` |
 | `-cloudwatch-concurrency.per-api-limit-enabled` | Enables a concurrency limiter, that has a specific limit per CloudWatch API call. | `false` |
 | `-cloudwatch-concurrency.list-metrics-limit` | Maximum number of concurrent requests to CloudWatch `ListMetrics` API. Only applicable if `per-api-limit-enabled` is `true`. | `5` |

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,13 +47,14 @@ type CloudWatchConcurrencyConfig struct {
 // is executed, and are commonly supplied by callers such as the YACE CLI or
 // downstream tools that embed YACE.
 type Config struct {
-	ScrapeConfigFile      string
-	MetricsPerQuery       int
-	LabelsSnakeCase       bool
-	TaggingAPIConcurrency int
-	FeatureFlags          []string
-	FIPSEnabled           bool
-	CloudwatchConcurrency CloudWatchConcurrencyConfig
+	ScrapeConfigFile          string
+	MetricsPerQuery           int
+	LabelsSnakeCase           bool
+	TaggingAPIConcurrency     int
+	FeatureFlags              []string
+	FIPSEnabled               bool
+	DisableAccountAliasLookup bool
+	CloudwatchConcurrency     CloudWatchConcurrencyConfig
 }
 
 func DefaultConfig() Config {

--- a/pkg/job/scrape.go
+++ b/pkg/job/scrape.go
@@ -35,6 +35,7 @@ func ScrapeAwsData(
 	metricsPerQuery int,
 	cloudwatchConcurrency cloudwatch.ConcurrencyConfig,
 	taggingAPIConcurrency int,
+	disableAccountAliasLookup bool,
 ) ([]model.TaggedResourceResult, []model.CloudwatchMetricResult) {
 	mux := &sync.Mutex{}
 	cwData := make([]model.CloudwatchMetricResult, 0)
@@ -74,9 +75,12 @@ func ScrapeAwsData(
 					}
 					jobLogger = jobLogger.With("account", accountID)
 
-					accountAlias, err := factory.GetAccountClient(region, role).GetAccountAlias(ctx)
-					if err != nil {
-						jobLogger.Warn("Couldn't get account alias", "err", err)
+					var accountAlias string
+					if !disableAccountAliasLookup {
+						accountAlias, err = factory.GetAccountClient(region, role).GetAccountAlias(ctx)
+						if err != nil {
+							jobLogger.Warn("Couldn't get account alias", "err", err)
+						}
 					}
 
 					cloudwatchClient := factory.GetCloudwatchClient(region, role, cloudwatchConcurrency)
@@ -140,9 +144,12 @@ func ScrapeAwsData(
 					}
 					jobLogger = jobLogger.With("account", accountID)
 
-					accountAlias, err := factory.GetAccountClient(region, role).GetAccountAlias(ctx)
-					if err != nil {
-						jobLogger.Warn("Couldn't get account alias", "err", err)
+					var accountAlias string
+					if !disableAccountAliasLookup {
+						accountAlias, err = factory.GetAccountClient(region, role).GetAccountAlias(ctx)
+						if err != nil {
+							jobLogger.Warn("Couldn't get account alias", "err", err)
+						}
 					}
 
 					metrics := runStaticJob(ctx, jobLogger, staticJob, factory.GetCloudwatchClient(region, role, cloudwatchConcurrency))
@@ -177,9 +184,12 @@ func ScrapeAwsData(
 					}
 					jobLogger = jobLogger.With("account", accountID)
 
-					accountAlias, err := factory.GetAccountClient(region, role).GetAccountAlias(ctx)
-					if err != nil {
-						jobLogger.Warn("Couldn't get account alias", "err", err)
+					var accountAlias string
+					if !disableAccountAliasLookup {
+						accountAlias, err = factory.GetAccountClient(region, role).GetAccountAlias(ctx)
+						if err != nil {
+							jobLogger.Warn("Couldn't get account alias", "err", err)
+						}
 					}
 
 					cloudwatchClient := factory.GetCloudwatchClient(region, role, cloudwatchConcurrency)

--- a/pkg/job/scraper.go
+++ b/pkg/job/scraper.go
@@ -25,9 +25,10 @@ import (
 )
 
 type Scraper struct {
-	jobsCfg       model.JobsConfig
-	logger        *slog.Logger
-	runnerFactory runnerFactory
+	jobsCfg                   model.JobsConfig
+	logger                    *slog.Logger
+	runnerFactory             runnerFactory
+	disableAccountAliasLookup bool
 }
 
 type runnerFactory interface {
@@ -47,11 +48,13 @@ type CloudwatchRunner interface {
 func NewScraper(logger *slog.Logger,
 	jobsCfg model.JobsConfig,
 	runnerFactory runnerFactory,
+	disableAccountAliasLookup bool,
 ) *Scraper {
 	return &Scraper{
-		runnerFactory: runnerFactory,
-		logger:        logger,
-		jobsCfg:       jobsCfg,
+		runnerFactory:             runnerFactory,
+		logger:                    logger,
+		jobsCfg:                   jobsCfg,
+		disableAccountAliasLookup: disableAccountAliasLookup,
 	}
 }
 
@@ -84,11 +87,13 @@ func (s Scraper) Scrape(ctx context.Context) ([]model.TaggedResourceResult, []mo
 			a := Account{
 				ID: accountID,
 			}
-			accountAlias, err := client.GetAccountAlias(ctx)
-			if err != nil {
-				s.logger.Warn("Failed to get optional account alias from account", "err", err, "account_id", accountID)
-			} else {
-				a.Alias = accountAlias
+			if !s.disableAccountAliasLookup {
+				accountAlias, err := client.GetAccountAlias(ctx)
+				if err != nil {
+					s.logger.Warn("Failed to get optional account alias from account", "err", err, "account_id", accountID)
+				} else {
+					a.Alias = accountAlias
+				}
 			}
 			return a, nil
 		})

--- a/pkg/job/scraper_test.go
+++ b/pkg/job/scraper_test.go
@@ -543,7 +543,7 @@ func TestScrapeRunner_Run(t *testing.T) {
 			}
 			lvl := promslog.NewLevel()
 			_ = lvl.Set("debug")
-			sr := job.NewScraper(promslog.New(&promslog.Config{Level: lvl}), tc.jobsCfg, &rf)
+			sr := job.NewScraper(promslog.New(&promslog.Config{Level: lvl}), tc.jobsCfg, &rf, false)
 			resources, metrics, errs := sr.Scrape(context.Background())
 
 			changelog, err := diff.Diff(tc.expectedResources, resources)

--- a/pkg/metrics/build.go
+++ b/pkg/metrics/build.go
@@ -67,6 +67,7 @@ func (s *Scraper) Scrape(ctx context.Context) ([]*promutil.PrometheusMetric, err
 		s.cfg.MetricsPerQuery,
 		toCloudWatchConcurrency(s.cfg.CloudwatchConcurrency),
 		s.cfg.TaggingAPIConcurrency,
+		s.cfg.DisableAccountAliasLookup,
 	)
 
 	metrics, observedMetricLabels, err := promutil.BuildMetrics(cloudwatchData, s.cfg.LabelsSnakeCase, s.logger)


### PR DESCRIPTION
Adds a CLI flag to skip the IAM ListAccountAliases API call during scrapes. When enabled, the account_alias label on metrics will be empty.

This is useful in environments where:
- IAM global endpoint access is restricted or undesirable. For us this is generating tons of undue firewall egress sessions and the call isn't needed in our config.
- The account alias is redundant with customTags configuration. In our case we don't need the alias as its already a custom tag due to dynamic config generation.

Related to #1853
Related to #1541